### PR TITLE
Attach to Process using provided PID and retrieve Camel BacklogDebugger  MBean

### DIFF
--- a/.settings/Test camel-dap-server.launch
+++ b/.settings/Test camel-dap-server.launch
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
+    <stringAttribute key="bad_container_name" value="/camel-dap-server/.setti"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/camel-dap-server"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="4"/>
+    </listAttribute>
+    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=camel-dap-server"/>
+    <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+    <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit5"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="camel-dap-server"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea -Djdk.attach.allowAttachSelf=true"/>
+</launchConfiguration>

--- a/.settings/camel-debug-adapter.launch
+++ b/.settings/camel-debug-adapter.launch
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
+    <booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
+    <stringAttribute key="M2_GOALS" value="clean install"/>
+    <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
+    <booleanAttribute key="M2_OFFLINE" value="false"/>
+    <stringAttribute key="M2_PROFILES" value=""/>
+    <listAttribute key="M2_PROPERTIES"/>
+    <stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
+    <booleanAttribute key="M2_SKIP_TESTS" value="false"/>
+    <intAttribute key="M2_THREADS" value="1"/>
+    <booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
+    <stringAttribute key="M2_USER_SETTINGS" value=""/>
+    <booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${project_loc:camel-dap-server}"/>
+</launchConfiguration>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,8 @@
 
 		<sonar.organization>camel-tooling</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
+
+		<version.camel>3.15.0-SNAPSHOT</version.camel>
 	</properties>
 
 	<build>
@@ -47,6 +49,9 @@
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.22.2</version>
+				<configuration>
+					<argLine>-Djdk.attach.allowAttachSelf=true</argLine>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.jacoco</groupId>
@@ -62,7 +67,7 @@
 				</executions>
 			</plugin>
 		</plugins>
-		
+
 
 		<pluginManagement>
 			<plugins>
@@ -89,9 +94,14 @@
 			<version>0.12.0</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-management-api</artifactId>
+			<version>${version.camel}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>5.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -100,5 +110,49 @@
 			<version>3.22.0</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-core</artifactId>
+			<version>${version.camel}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-management</artifactId>
+			<version>${version.camel}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-debug</artifactId>
+			<version>${version.camel}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.junit</groupId>
+				<artifactId>junit-bom</artifactId>
+				<version>5.8.2</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<repositories>
+		<repository>
+			<id>apache.snapshots</id>
+			<name>Apache Development Snapshot Repository</name>
+			<url>https://repository.apache.org/content/repositories/snapshots/</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
 </project>

--- a/src/main/java/com/github/cameltooling/dap/internal/BacklogDebuggerConnectionManager.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/BacklogDebuggerConnectionManager.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import javax.management.JMX;
+import javax.management.MBeanServerConnection;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+
+import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
+
+import com.sun.tools.attach.VirtualMachine;
+
+public class BacklogDebuggerConnectionManager {
+
+	private static final String DEFAULT_JMX_URI = "service:jmx:rmi:///jndi/rmi://localhost:1099/jmxrmi";
+
+	public static final String ATTACH_PARAM_PID = "attach_pid";
+
+	private JMXConnector jmxConnector;
+	private MBeanServerConnection mbeanConnection;
+	private ManagedBacklogDebuggerMBean backlogDebugger;
+
+	private String getLocalJMXUrl(String javaProcessPID) {
+		try {
+			final String localConnectorAddressProperty = "com.sun.management.jmxremote.localConnectorAddress";
+			VirtualMachine vm = VirtualMachine.attach(javaProcessPID);
+			vm.startLocalManagementAgent();
+			String localJmxUrl = vm.getAgentProperties().getProperty(localConnectorAddressProperty);
+			vm.detach();
+			return localJmxUrl;
+		} catch (Exception e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+	public void attach(Map<String, Object> args) {
+		try {
+			String jmxAddress = DEFAULT_JMX_URI;
+			Object pid = args.get(ATTACH_PARAM_PID);
+			if (pid != null) {
+				jmxAddress = getLocalJMXUrl((String) pid);
+			}
+			JMXServiceURL jmxUrl = new JMXServiceURL(jmxAddress);
+			jmxConnector = JMXConnectorFactory.connect(jmxUrl);
+			mbeanConnection = jmxConnector.getMBeanServerConnection();
+			ObjectName objectName = new ObjectName("org.apache.camel:context=*,type=tracer,name=BacklogDebugger");
+			Set<ObjectName> names = mbeanConnection.queryNames(objectName, null);
+			if (names != null && !names.isEmpty()) {
+				ObjectName debuggerMBeanObjectName = names.iterator().next();
+				backlogDebugger = JMX.newMBeanProxy(
+						mbeanConnection,
+						debuggerMBeanObjectName,
+						ManagedBacklogDebuggerMBean.class);
+			} else {
+				// TODO: log something or send a message to client
+			}
+		} catch (IOException | MalformedObjectNameException e) {
+			e.printStackTrace();
+		}
+	}
+
+	public void terminate() {
+		if (jmxConnector != null) {
+			try {
+				jmxConnector.close();
+			} catch (IOException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		}
+
+	}
+
+	public MBeanServerConnection getMbeanConnection() {
+		return mbeanConnection;
+	}
+
+	public ManagedBacklogDebuggerMBean getBacklogDebugger() {
+		return backlogDebugger;
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServer.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServer.java
@@ -16,16 +16,19 @@
  */
 package com.github.cameltooling.dap.internal;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.lsp4j.debug.Capabilities;
 import org.eclipse.lsp4j.debug.InitializeRequestArguments;
+import org.eclipse.lsp4j.debug.TerminateArguments;
 import org.eclipse.lsp4j.debug.services.IDebugProtocolClient;
 import org.eclipse.lsp4j.debug.services.IDebugProtocolServer;
 
 public class CamelDebugAdapterServer implements IDebugProtocolServer {
 
 	private IDebugProtocolClient client;
+	private BacklogDebuggerConnectionManager connectionManager = new BacklogDebuggerConnectionManager();
 
 	public void connect(IDebugProtocolClient clientProxy) {
 		this.client = clientProxy;
@@ -36,4 +39,22 @@ public class CamelDebugAdapterServer implements IDebugProtocolServer {
 		client.initialized();
 		return CompletableFuture.completedFuture(new Capabilities());
 	}
+	
+	@Override
+	public CompletableFuture<Void> attach(Map<String, Object> args) {
+		connectionManager.attach(args);
+		return CompletableFuture.completedFuture(null);
+	}
+
+	
+	@Override
+	public CompletableFuture<Void> terminate(TerminateArguments args) {
+		getConnectionManager().terminate();
+		return CompletableFuture.completedFuture(null);
+	}
+
+	public BacklogDebuggerConnectionManager getConnectionManager() {
+		return connectionManager;
+	}
+
 }

--- a/src/test/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServerTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServerTest.java
@@ -18,24 +18,71 @@ package com.github.cameltooling.dap.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
 import org.eclipse.lsp4j.debug.Capabilities;
 import org.eclipse.lsp4j.debug.InitializeRequestArguments;
+import org.eclipse.lsp4j.debug.TerminateArguments;
+import org.eclipse.lsp4j.debug.TerminatedEventArguments;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class CamelDebugAdapterServerTest {
+	
+	private CamelDebugAdapterServer server;
+	private DummyCamelDebugClient clientProxy;
+	
+	@AfterEach
+	void tearDown() {
+		if (server != null) {
+			server.terminate(new TerminateArguments());
+			server = null;
+		}
+		if (clientProxy != null) {
+			clientProxy.terminated(new TerminatedEventArguments());
+			clientProxy = null;
+		}
+	}
 
 	@Test
 	void testInitialize() throws InterruptedException, ExecutionException {
-		CamelDebugAdapterServer server = new CamelDebugAdapterServer();
-		DummyCamelDebugClient clientProxy = new DummyCamelDebugClient();
-		server.connect(clientProxy);
-		CompletableFuture<Capabilities> initialization = server.initialize(new InitializeRequestArguments());
+		CompletableFuture<Capabilities> initialization = initDebugger();
 		assertThat(initialization.get()).isNotNull();
 		assertThat(clientProxy.hasReceivedInitializedEvent()).isTrue();
 		
+	}
+	
+	@Test
+	void testAttachToCamelWithPid() throws Exception {
+		try (CamelContext context = new DefaultCamelContext()) {
+			context.addRoutes(new RouteBuilder() {
+			
+				@Override
+				public void configure() throws Exception {
+					from("direct:test")
+						.log("Log from test");
+				}
+			});
+			context.start();
+			assertThat(context.isStarted()).isTrue();
+			initDebugger();
+			server.attach(Collections.singletonMap(BacklogDebuggerConnectionManager.ATTACH_PARAM_PID, Long.toString(ProcessHandle.current().pid())));
+			BacklogDebuggerConnectionManager connectionManager = server.getConnectionManager();
+			assertThat(connectionManager.getMbeanConnection()).as("The MBeanConnection has not been established.").isNotNull();
+			assertThat(connectionManager.getBacklogDebugger()).as("The BacklogDebugger has not been found.").isNotNull();
+		}
+	}
+	
+	private CompletableFuture<Capabilities> initDebugger() {
+		server = new CamelDebugAdapterServer();
+		clientProxy = new DummyCamelDebugClient();
+		server.connect(clientProxy);
+		return server.initialize(new InitializeRequestArguments());
 	}
 
 }


### PR DESCRIPTION
- from PID, able to retrieve the JMX connection (using sun.tools but not
found a better way)
- allow self attach when launching test so that we can have the Camel
route in the same VM in the tests. Won't be necessary at runtime.
- it requires Camel 3.15

kudos to @javaduke which helped and pointed to helpful code from
IntelliJ extension
https://github.com/javaduke/camel-idea-plugin/blob/main/camel-idea-plugin/src/main/java/com/github/cameltooling/idea/runner/debugger/CamelDebuggerSession.java#L505