### PR TITLE
Fix code coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.22.2</version>
 				<configuration>
-					<argLine>-Djdk.attach.allowAttachSelf=true</argLine>
+					<argLine>@{argLine} -Djdk.attach.allowAttachSelf=true</argLine>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
using argLine is overriding the argLine set by Jacoco Maven plugin and
so failing to provide coverage. Using the (cleaner) systemProperties
configuration tag avoids to override the argLine

Signed-off-by: Aurélien Pupier <apupier@redhat.com>