### PR TITLE
Use one thread per exchange

### DIFF
--- a/src/main/java/com/github/cameltooling/dap/internal/IdUtils.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/IdUtils.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal;
+
+public class IdUtils {
+	
+	private IdUtils() {}
+
+	public static int getPositiveIntFromHashCode(int hashCode) {
+		return hashCode & 0x7fffffff;
+	}
+	
+}

--- a/src/main/java/com/github/cameltooling/dap/internal/model/CamelBreakpoint.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/CamelBreakpoint.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal.model;
+
+import org.eclipse.lsp4j.debug.Breakpoint;
+import org.eclipse.lsp4j.debug.Source;
+
+public class CamelBreakpoint extends Breakpoint {
+
+	private String nodeId;
+
+	public CamelBreakpoint(Source source, int line) {
+		setSource(source);
+		setLine(line);
+	}
+	
+	public String getNodeId() {
+		return nodeId;
+	}
+
+	public void setNodeId(String nodeId) {
+		this.nodeId = nodeId;
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/dap/internal/model/CamelStackFrame.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/CamelStackFrame.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal.model;
+
+import org.eclipse.lsp4j.debug.Source;
+import org.eclipse.lsp4j.debug.StackFrame;
+
+import com.github.cameltooling.dap.internal.types.EventMessage;
+
+public class CamelStackFrame extends StackFrame {
+
+	private EventMessage eventMessage;
+
+	public CamelStackFrame(int frameId, String breakpointId, EventMessage eventMessage, Source source, Integer line) {
+		this.eventMessage = eventMessage;
+		setId(frameId);
+		setName(breakpointId);
+		setSource(source);
+		setLine(line);
+	}
+
+}

--- a/src/test/java/com/github/cameltooling/dap/internal/BasicDebugFlowTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/BasicDebugFlowTest.java
@@ -88,7 +88,7 @@ class BasicDebugFlowTest extends BaseTest {
 			
 			waitBreakpointNotification(1);
 			StoppedEventArguments stoppedEventArgument = clientProxy.getStoppedEventArguments().get(0);
-			assertThat(stoppedEventArgument.getThreadId()).isZero();
+			assertThat(stoppedEventArgument.getThreadId()).isEqualTo(1);
 			assertThat(stoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
 			
 			assertThat(asyncSendBody.isDone()).isFalse();

--- a/src/test/java/com/github/cameltooling/dap/internal/DummyCamelDebugClient.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/DummyCamelDebugClient.java
@@ -29,6 +29,7 @@ import org.eclipse.lsp4j.debug.StackTraceArguments;
 import org.eclipse.lsp4j.debug.StackTraceResponse;
 import org.eclipse.lsp4j.debug.StoppedEventArguments;
 import org.eclipse.lsp4j.debug.Thread;
+import org.eclipse.lsp4j.debug.ThreadEventArguments;
 import org.eclipse.lsp4j.debug.ThreadsResponse;
 import org.eclipse.lsp4j.debug.Variable;
 import org.eclipse.lsp4j.debug.VariablesArguments;
@@ -40,6 +41,7 @@ public class DummyCamelDebugClient implements IDebugProtocolClient {
 	private boolean hasReceivedInitializedEvent;
 	private List<StoppedEventArguments> stoppedEventArguments = new ArrayList<>();
 	private List<StackAndVarOnStopEvent> wholeStackAndVars = new ArrayList<>();
+	private List<ThreadEventArguments> threadEventArgumentss = new ArrayList<>();
 	private CamelDebugAdapterServer server;
 
 	public DummyCamelDebugClient(CamelDebugAdapterServer server) {
@@ -106,6 +108,11 @@ public class DummyCamelDebugClient implements IDebugProtocolClient {
 		
 		
 	}
+	
+	@Override
+	public void thread(ThreadEventArguments args) {
+		threadEventArgumentss.add(args);
+	}
 
 	public List<StoppedEventArguments> getStoppedEventArguments() {
 		return stoppedEventArguments;
@@ -113,6 +120,10 @@ public class DummyCamelDebugClient implements IDebugProtocolClient {
 
 	public List<StackAndVarOnStopEvent> getAllStacksAndVars() {
 		return wholeStackAndVars;
+	}
+
+	public List<ThreadEventArguments> getThreadEventArgumentss() {
+		return threadEventArgumentss;
 	}
 
 }

--- a/src/test/java/com/github/cameltooling/dap/internal/MultipleThreadsTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/MultipleThreadsTest.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.engine.DefaultProducerTemplate;
+import org.eclipse.lsp4j.debug.ContinueArguments;
+import org.eclipse.lsp4j.debug.SetBreakpointsArguments;
+import org.eclipse.lsp4j.debug.StoppedEventArguments;
+import org.eclipse.lsp4j.debug.StoppedEventArgumentsReason;
+import org.eclipse.lsp4j.debug.ThreadEventArgumentsReason;
+import org.junit.jupiter.api.Test;
+
+class MultipleThreadsTest extends BaseTest {
+
+	@Test
+	void test2SuspendedBreakpointsCreates2Threads() throws Exception {
+		try (CamelContext context = new DefaultCamelContext()) {
+			String startEndpointUri1 = "direct:testThreads1";
+			String startEndpointUri2 = "direct:testThreads2";
+			context.addRoutes(new RouteBuilder() {
+			
+				@Override
+				public void configure() throws Exception {
+					from(startEndpointUri1)
+						.log("Log from test 1");  // line number to use from here
+					
+					from(startEndpointUri2)
+						.log("Log from test 2");  // line number to use from here
+				}
+			});
+			context.start();
+			assertThat(context.isStarted()).isTrue();
+			initDebugger();
+			attach(server);
+			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument(46, 49);
+			
+			server.setBreakpoints(setBreakpointsArguments).get();
+			
+			DefaultProducerTemplate producerTemplate = DefaultProducerTemplate.newInstance(context, startEndpointUri1);
+			producerTemplate.start();
+			
+			CompletableFuture<Object> asyncSendBody1 = producerTemplate.asyncSendBody(startEndpointUri1, "a body 1");
+			CompletableFuture<Object> asyncSendBody2 = producerTemplate.asyncSendBody(startEndpointUri2, "a body 2");
+			
+			waitBreakpointNotification(2);
+			StoppedEventArguments stoppedEventArgument1 = clientProxy.getStoppedEventArguments().get(0);
+			assertThat(stoppedEventArgument1.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
+			assertThat(clientProxy.getThreadEventArgumentss()).hasSize(2);
+			assertThat(clientProxy.getThreadEventArgumentss().stream().filter(args -> ThreadEventArgumentsReason.STARTED.equals(args.getReason()))).hasSize(2);
+			
+			assertThat(asyncSendBody1.isDone()).isFalse();
+			assertThat(asyncSendBody2.isDone()).isFalse();	
+			
+			assertThat(clientProxy.getAllStacksAndVars()).hasSize(2);
+			assertThat(clientProxy.getAllStacksAndVars().get(0).getStackFrames()).hasSize(1);
+			server.continue_(new ContinueArguments());
+			
+			waitRouteIsDone(asyncSendBody1);
+			waitRouteIsDone(asyncSendBody2);
+			assertThat(clientProxy.getThreadEventArgumentss()).hasSize(4);
+			assertThat(clientProxy.getThreadEventArgumentss().stream().filter(args -> ThreadEventArgumentsReason.EXITED.equals(args.getReason()))).hasSize(2);
+			
+			producerTemplate.stop();
+		}
+	}
+	
+}

--- a/src/test/java/com/github/cameltooling/dap/internal/RemoveBreakpointTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/RemoveBreakpointTest.java
@@ -71,7 +71,7 @@ class RemoveBreakpointTest extends BaseTest {
 		
 		waitBreakpointNotification(1);
 		StoppedEventArguments stoppedEventArgument = clientProxy.getStoppedEventArguments().get(0);
-		assertThat(stoppedEventArgument.getThreadId()).isZero();
+		assertThat(stoppedEventArgument.getThreadId()).isEqualTo(1);
 		assertThat(stoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
 		
 		assertThat(asyncSendBody.isDone()).isFalse();


### PR DESCRIPTION
- Showing threads only for stopped message. It would bloats the UI too
much on each running message and surely make it flickering.
- Call Starting/exiting Threads when breakpoint hit, resume all. Threads
id are not reused but this is an arbitrary number anyway. The name is
more important for the end-user perspective, it is the exchange ID.
Cannot use the Exchange ID as thread id because the threadid in Debug
Adapter protocol specification is a number and Exchange ID is a string.
- it is important for Eclipse client to call the thread start and stop,
otherwise, it is not clearing the list of threds even after a new call
on threads() method

![OneThreadPerExchange](https://user-images.githubusercontent.com/1105127/150755258-8895b3f7-e910-42d3-8571-dd580f36a9bc.gif)
