### PR TITLE
Upgrade slf4j-api to 1.7.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.32</version>
+			<version>1.7.33</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
note: waiting 3.15 camel release and removal of apache snapshots from repositories to use dependabot, see https://issues.redhat.com/browse/FUSETOOLS2-1448