### PR TITLE
Remove workaround for launch

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -25,6 +25,13 @@ To test with the Client integration of Eclipse IDE:
   - In `command` field, set `java`
   - In `Arguments` field, set `-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=3000 -jar <pathTo>/camel-dap-server-xxx.jar`
   - Select `Monitor Debug Adapter launch process`
-  - In `Launch Parameters (Json)` field, set { "attach_pid": "<thePidOfTheCamelApplication>"}
+  - In `Launch Parameters (Json)` field, set
+  
+  ```json
+  {
+   "request": "attach",
+   "attach_pid": "<thePidOfTheCamelApplication>"
+  }
+  ```
   - Click `Debug`
 - You can now set breakpoints in textual Camel route definition and Camel Debug Adapter project

--- a/src/main/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServer.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServer.java
@@ -92,12 +92,6 @@ public class CamelDebugAdapterServer implements IDebugProtocolServer {
 	}
 	
 	@Override
-	public CompletableFuture<Void> launch(Map<String, Object> args) {
-		// TODO: built-in Debug Configuration launch in Eclipse only allows to launch and not attach. So here is a trick.
-		return attach(args);
-	}
-	
-	@Override
 	public CompletableFuture<Void> attach(Map<String, Object> args) {
 		connectionManager.attach(args, client);
 		return CompletableFuture.completedFuture(null);


### PR DESCRIPTION
launch request is not supported by Camel Debug Adapter server, it was
redirecting to the attach because I wasn't aware of the `"request": "attach"` parameter see
https://github.com/eclipse/lsp4e/issues/49#issuecomment-1020190833

thanks to @jonahgraham for pointing it out

Signed-off-by: Aurélien Pupier <apupier@redhat.com>