### PR TITLE
FUSETOOLS2-1449 - await that debugger initialized method has returned

### DIFF
--- a/src/main/java/com/github/cameltooling/dap/internal/BacklogDebuggerConnectionManager.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/BacklogDebuggerConnectionManager.java
@@ -92,6 +92,7 @@ public class BacklogDebuggerConnectionManager {
 			if (pid != null) {
 				jmxAddress = getLocalJMXUrl((String) pid);
 			}
+			LOGGER.error("Will use JMX adress: {}", jmxAddress);
 			JMXServiceURL jmxUrl = new JMXServiceURL(jmxAddress);
 			jmxConnector = JMXConnectorFactory.connect(jmxUrl);
 			mbeanConnection = jmxConnector.getMBeanServerConnection();

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -29,5 +29,5 @@ appender.rolling.strategy.delete.ifLastModified.type = IfLastModified
 appender.rolling.strategy.delete.ifLastModified.age = 30d
 
 # Configure root logger
-rootLogger.level = debug
+rootLogger.level = trace
 rootLogger.appenderRef.rolling.ref = fileLogger

--- a/src/test/java/com/github/cameltooling/dap/internal/BaseTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/BaseTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import org.eclipse.lsp4j.debug.Capabilities;
 import org.eclipse.lsp4j.debug.InitializeRequestArguments;
@@ -103,11 +104,11 @@ public abstract class BaseTest {
 		return setBreakpointsArguments;
 	}
 
-	protected CompletableFuture<Capabilities> initDebugger() {
+	protected Capabilities initDebugger() throws InterruptedException, ExecutionException {
 		server = new CamelDebugAdapterServer();
 		clientProxy = new DummyCamelDebugClient(server);
 		server.connect(clientProxy);
-		return server.initialize(new InitializeRequestArguments());
+		return server.initialize(new InitializeRequestArguments()).get();
 	}
 
 }

--- a/src/test/java/com/github/cameltooling/dap/internal/BasicDebugFlowTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/BasicDebugFlowTest.java
@@ -49,6 +49,8 @@ class BasicDebugFlowTest extends BaseTest {
 	@Test
 	void testBasicFlow() throws Exception {
 		try (CamelContext context = new DefaultCamelContext()) {
+			context.start();
+			assertThat(context.isStarted()).isTrue();
 			String routeId = "a-route-id";
 			String logEndpointId = "testBasicFlow-log-id";
 			context.addRoutes(new RouteBuilder() {
@@ -64,9 +66,7 @@ class BasicDebugFlowTest extends BaseTest {
 						.log("Log from test").id(logEndpointId); // line number to use from here
 				}
 			});
-			int lineNumberToPutBreakpoint = 64;
-			context.start();
-			assertThat(context.isStarted()).isTrue();
+			int lineNumberToPutBreakpoint = 66;
 			initDebugger();
 			attach(server);
 			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument(lineNumberToPutBreakpoint);

--- a/src/test/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServerTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServerTest.java
@@ -38,6 +38,8 @@ class CamelDebugAdapterServerTest extends BaseTest {
 	@Test
 	void testAttachToCamelWithPid() throws Exception {
 		try (CamelContext context = new DefaultCamelContext()) {
+			context.start();
+			assertThat(context.isStarted()).isTrue();
 			context.addRoutes(new RouteBuilder() {
 			
 				@Override
@@ -46,8 +48,6 @@ class CamelDebugAdapterServerTest extends BaseTest {
 						.log("Log from test");
 				}
 			});
-			context.start();
-			assertThat(context.isStarted()).isTrue();
 			initDebugger();
 			attach(server);
 			BacklogDebuggerConnectionManager connectionManager = server.getConnectionManager();

--- a/src/test/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServerTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServerTest.java
@@ -18,7 +18,6 @@ package com.github.cameltooling.dap.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.camel.CamelContext;
@@ -31,8 +30,8 @@ class CamelDebugAdapterServerTest extends BaseTest {
 	
 	@Test
 	void testInitialize() throws InterruptedException, ExecutionException {
-		CompletableFuture<Capabilities> initialization = initDebugger();
-		assertThat(initialization.get()).isNotNull();
+		Capabilities capabilities = initDebugger();
+		assertThat(capabilities).isNotNull();
 		assertThat(clientProxy.hasReceivedInitializedEvent()).isTrue();
 	}
 	

--- a/src/test/java/com/github/cameltooling/dap/internal/MultipleThreadsTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/MultipleThreadsTest.java
@@ -38,6 +38,8 @@ class MultipleThreadsTest extends BaseTest {
 		try (CamelContext context = new DefaultCamelContext()) {
 			String startEndpointUri1 = "direct:testThreads1";
 			String startEndpointUri2 = "direct:testThreads2";
+			context.start();
+			assertThat(context.isStarted()).isTrue();
 			context.addRoutes(new RouteBuilder() {
 			
 				@Override
@@ -49,11 +51,9 @@ class MultipleThreadsTest extends BaseTest {
 						.log("Log from test 2");  // line number to use from here
 				}
 			});
-			context.start();
-			assertThat(context.isStarted()).isTrue();
 			initDebugger();
 			attach(server);
-			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument(46, 49);
+			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument(48, 51);
 			
 			server.setBreakpoints(setBreakpointsArguments).get();
 			

--- a/src/test/java/com/github/cameltooling/dap/internal/RemoveBreakpointTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/RemoveBreakpointTest.java
@@ -36,6 +36,8 @@ class RemoveBreakpointTest extends BaseTest {
 	void testRemoveOneBreakpoint() throws Exception {
 		try (CamelContext context = new DefaultCamelContext()) {
 			String fromUri = "direct:testRemoveBreakpoint";
+			context.start();
+			assertThat(context.isStarted()).isTrue();
 			context.addRoutes(new RouteBuilder() {
 			
 				@Override
@@ -44,9 +46,7 @@ class RemoveBreakpointTest extends BaseTest {
 						.log("Log from test"); // line number to use from here
 				}
 			});
-			int lineNumberToPutBreakpoint = 44;
-			context.start();
-			assertThat(context.isStarted()).isTrue();
+			int lineNumberToPutBreakpoint = 46;
 			initDebugger();
 			attach(server);
 			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument(lineNumberToPutBreakpoint);

--- a/src/test/java/com/github/cameltooling/dap/internal/ResumeAllTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/ResumeAllTest.java
@@ -38,6 +38,8 @@ class ResumeAllTest extends BaseTest {
 	@Test
 	void testResumeAndSecondBreakpointHitOfAnotherRouteInstance() throws Exception {
 		try (CamelContext context = new DefaultCamelContext()) {
+			context.start();
+			assertThat(context.isStarted()).isTrue();
 			String routeId = "a-route-id";
 			String startEndpointUri = "direct:testResume";
 			context.addRoutes(new RouteBuilder() {
@@ -49,9 +51,7 @@ class ResumeAllTest extends BaseTest {
 						.log("Log from test");  // line number to use from here
 				}
 			});
-			int lineNumberToPutBreakpoint = 49;
-			context.start();
-			assertThat(context.isStarted()).isTrue();
+			int lineNumberToPutBreakpoint = 51;
 			initDebugger();
 			attach(server);
 			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument(lineNumberToPutBreakpoint);
@@ -108,6 +108,8 @@ class ResumeAllTest extends BaseTest {
 		try (CamelContext context = new DefaultCamelContext()) {
 			String routeId = "a-route-id";
 			String startEndpointUri = "direct:testResume";
+			context.start();
+			assertThat(context.isStarted()).isTrue();
 			context.addRoutes(new RouteBuilder() {
 			
 				@Override
@@ -118,10 +120,8 @@ class ResumeAllTest extends BaseTest {
 						.log("second log");
 				}
 			});
-			int firstLineNumberToPutBreakpoint = 117;
+			int firstLineNumberToPutBreakpoint = 119;
 			int secondLineNumberToPutBreakpoint = firstLineNumberToPutBreakpoint + 1;
-			context.start();
-			assertThat(context.isStarted()).isTrue();
 			initDebugger();
 			attach(server);
 			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument(firstLineNumberToPutBreakpoint, secondLineNumberToPutBreakpoint);


### PR DESCRIPTION
before trying to use the debugger in the tests. It should avoid
flakiness on CI.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>