### PR TITLE
FUSETOOLS2-1458 - Sign jar on Main branch

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,4 @@
-name: Sonar analysis
+name: Main branch - Sonar analysis and Signing
 
 on:
   push:
@@ -19,14 +19,18 @@ jobs:
         java-version: 11
         distribution: 'adopt'
         cache: 'maven'
+        gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+        gpg-passphrase: MAVEN_GPG_PASSPHRASE
     - name: Cache SonarCloud packages
       uses: actions/cache@v1
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
-    - name: Build with Maven
-      run: mvn -B package
+    - name: Build and sign with Maven
+      run: mvn -P sign -B verify
+      env:
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
     - name: Sonar analysis
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.camel-tooling</groupId>
 	<artifactId>camel-dap-server</artifactId>
@@ -211,6 +213,30 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
+
+	<profiles>
+		<profile>
+			<id>sign</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>3.0.1</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 	<repositories>
 		<repository>


### PR DESCRIPTION
see https://github.com/camel-tooling/camel-debug-adapter/runs/4981883859?check_suite_focus=true#step:4:131 for a modified branch allowing to see successful signing

- 2 secrets have been provided on GitHub camel-debug-adapter repository:
MAVEN_GPG_PRIVATE_KEY and MAVEN_GPG_PASSPHRASE . They are mine (apupier)
gpg keys and passphrase. The private key must be provided including the
"delimiters" `-----BEGIN PGP PRIVATE KEY BLOCK-----` and `-----END PGP
PRIVATE KEY BLOCK-----`
- the signing is done in verify phase so modified job for it
- the signing requires to be on a branch from the repository as it is
using secrets so cannot be tested on a normal Pull Request. That's the
reason of the profile to sign.
- doing the Sonar and Signing in the same Github Action flow to avoid
rebuilding and replaying test on the same configuration. The deploy will
be added in the same job too in next phase.
- note: no need of pinentry loopback configuration as maven-gpg-plugin
3.0.1 is used
- most useful documentation:
https://central.sonatype.org/publish/requirements/gpg/ and
https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#publishing-using-apache-maven