### PR TITLE
FUSETOOLS2-1433 - resume a single thread

### DIFF
--- a/src/main/java/com/github/cameltooling/dap/internal/BacklogDebuggerConnectionManager.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/BacklogDebuggerConnectionManager.java
@@ -204,14 +204,18 @@ public class BacklogDebuggerConnectionManager {
 
 	public void resumeAll() {
 		for (CamelThread camelThread : camelThreads) {
-			ThreadEventArguments threadEventArguments = new ThreadEventArguments();
-			threadEventArguments.setReason(ThreadEventArgumentsReason.EXITED);
-			threadEventArguments.setThreadId(camelThread.getId());
-			client.thread(threadEventArguments);
+			sendThreadExitEvent(camelThread);
 		}
 		backlogDebugger.resumeAll();
 		camelThreads.clear();
 		notifiedSuspendedBreakpointIds.clear();
+	}
+
+	private void sendThreadExitEvent(CamelThread camelThread) {
+		ThreadEventArguments threadEventArguments = new ThreadEventArguments();
+		threadEventArguments.setReason(ThreadEventArgumentsReason.EXITED);
+		threadEventArguments.setThreadId(camelThread.getId());
+		client.thread(threadEventArguments);
 	}
 
 	public Set<CamelThread> getCamelThreads() {
@@ -225,6 +229,13 @@ public class BacklogDebuggerConnectionManager {
 	public void removeBreakpoint(String previouslySetBreakpointId) {
 		backlogDebugger.removeBreakpoint(previouslySetBreakpointId);
 		this.camelBreakpointsWithSources.remove(previouslySetBreakpointId);
+	}
+
+	public void resume(CamelThread camelThread) {
+		backlogDebugger.resumeBreakpoint(camelThread.getBreakPointId());
+		notifiedSuspendedBreakpointIds.remove(camelThread.getBreakPointId());
+		camelThreads.remove(camelThread);
+		sendThreadExitEvent(camelThread);
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/dap/internal/model/CamelDebuggerScope.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/CamelDebuggerScope.java
@@ -20,35 +20,25 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
-import org.eclipse.lsp4j.debug.Source;
-import org.eclipse.lsp4j.debug.StackFrame;
 import org.eclipse.lsp4j.debug.Variable;
 
-public class CamelStackFrame extends StackFrame {
+import com.github.cameltooling.dap.internal.IdUtils;
 
-	private Set<CamelScope> scopes = new HashSet<>();
+public class CamelDebuggerScope extends CamelScope {
 
-	public CamelStackFrame(int frameId, String breakpointId, Source source, Integer line) {
-		setId(frameId);
-		setName(breakpointId);
-		setSource(source);
-		setLine(line);
+	public CamelDebuggerScope(CamelStackFrame stackframe) {
+		super("Debugger", stackframe.getName(), IdUtils.getPositiveIntFromHashCode((stackframe.getId()+"@Debugger@" + stackframe.getName()).hashCode()));
 	}
 	
-	public Set<CamelScope> createScopes() {
-		scopes.clear();
-		scopes.add(new CamelDebuggerScope(this));
-		scopes.add(new CamelEndpointScope(this));
-		scopes.add(new CamelProcessorScope(this));
-		scopes.add(new CamelExchangeScope(this));
-		scopes.add(new CamelMessageScope(this));
-		return scopes;
-	}
-
 	public Set<Variable> createVariables(int variablesReference, ManagedBacklogDebuggerMBean debugger) {
 		Set<Variable> variables = new HashSet<>();
-		for (CamelScope camelScope : scopes) {
-			variables.addAll(camelScope.createVariables(variablesReference, debugger));
+		if(variablesReference == getVariablesReference()) {
+			variables.add(createVariable("Logging level", debugger.getLoggingLevel()));
+			variables.add(createVariable("Max chars for body", Integer.toString(debugger.getBodyMaxChars())));
+			variables.add(createVariable("Debug counter", Long.toString(debugger.getDebugCounter())));
+			variables.add(createVariable("Fallback timeout", Long.toString(debugger.getFallbackTimeout())));
+			variables.add(createVariable("Body include files", Boolean.toString(debugger.isBodyIncludeFiles())));
+			variables.add(createVariable("Body include streams", Boolean.toString(debugger.isBodyIncludeStreams())));
 		}
 		return variables;
 	}

--- a/src/main/java/com/github/cameltooling/dap/internal/model/CamelEndpointScope.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/CamelEndpointScope.java
@@ -20,37 +20,21 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
-import org.eclipse.lsp4j.debug.Source;
-import org.eclipse.lsp4j.debug.StackFrame;
 import org.eclipse.lsp4j.debug.Variable;
 
-public class CamelStackFrame extends StackFrame {
+import com.github.cameltooling.dap.internal.IdUtils;
 
-	private Set<CamelScope> scopes = new HashSet<>();
-
-	public CamelStackFrame(int frameId, String breakpointId, Source source, Integer line) {
-		setId(frameId);
-		setName(breakpointId);
-		setSource(source);
-		setLine(line);
+public class CamelEndpointScope extends CamelScope {
+	
+	public CamelEndpointScope(CamelStackFrame stackframe) {
+		super("Endpoint", stackframe.getName(), IdUtils.getPositiveIntFromHashCode((stackframe.getId()+"@Endpoint@" + stackframe.getName()).hashCode()));
 	}
 	
-	public Set<CamelScope> createScopes() {
-		scopes.clear();
-		scopes.add(new CamelDebuggerScope(this));
-		scopes.add(new CamelEndpointScope(this));
-		scopes.add(new CamelProcessorScope(this));
-		scopes.add(new CamelExchangeScope(this));
-		scopes.add(new CamelMessageScope(this));
-		return scopes;
-	}
-
 	public Set<Variable> createVariables(int variablesReference, ManagedBacklogDebuggerMBean debugger) {
 		Set<Variable> variables = new HashSet<>();
-		for (CamelScope camelScope : scopes) {
-			variables.addAll(camelScope.createVariables(variablesReference, debugger));
+		if (variablesReference == getVariablesReference()) {
+			variables.add(createVariable("Name", getName()));
 		}
 		return variables;
 	}
-
 }

--- a/src/main/java/com/github/cameltooling/dap/internal/model/CamelExchangeScope.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/CamelExchangeScope.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal.model;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
+import org.eclipse.lsp4j.debug.Variable;
+
+import com.github.cameltooling.dap.internal.IdUtils;
+import com.github.cameltooling.dap.internal.types.EventMessage;
+import com.github.cameltooling.dap.internal.types.ExchangeProperty;
+import com.github.cameltooling.dap.internal.types.UnmarshallerEventMessage;
+
+public class CamelExchangeScope extends CamelScope {
+	
+	private Map<Integer, List<ExchangeProperty>> variableReferenceToExchangeProperties = new HashMap<>();
+
+	public CamelExchangeScope(CamelStackFrame stackframe) {
+		super("Exchange", stackframe.getName(), IdUtils.getPositiveIntFromHashCode((stackframe.getId()+"@Exchange@" + stackframe.getName()).hashCode()));
+	}
+
+	@Override
+	public Set<Variable> createVariables(int variablesReference, ManagedBacklogDebuggerMBean debugger) {
+		Set<Variable> variables = new HashSet<>();
+		if (variablesReference == getVariablesReference()) {
+			String xml = debugger.dumpTracedMessagesAsXml(getBreakpointId(), true);
+			EventMessage eventMessage = new UnmarshallerEventMessage().getUnmarshalledEventMessage(xml);
+			if (eventMessage != null) {
+				variables.add(createVariable("ID", eventMessage.getExchangeId()));
+				variables.add(createVariable("To node", eventMessage.getToNode()));
+				variables.add(createVariable("Route ID", eventMessage.getRouteId()));
+				Variable exchangeVariable = new Variable();
+				exchangeVariable.setName("Properties");
+				exchangeVariable.setValue("");
+				int exchangeVarRefId = IdUtils.getPositiveIntFromHashCode((variablesReference + "@ExchangeProperties@").hashCode());
+				variableReferenceToExchangeProperties.put(exchangeVarRefId, eventMessage.getExchangeProperties());
+				exchangeVariable.setVariablesReference(exchangeVarRefId);
+				variables.add(exchangeVariable);
+			}
+		} else {
+			List<ExchangeProperty> exchangeProperties = variableReferenceToExchangeProperties.get(variablesReference);
+			if (exchangeProperties != null) {
+				for (ExchangeProperty exchangeProperty : exchangeProperties) {
+					variables.add(createVariable(exchangeProperty.getName(), exchangeProperty.getContent()));
+				}
+			}
+		}
+		return variables;
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/dap/internal/model/CamelMessageScope.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/CamelMessageScope.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal.model;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
+import org.eclipse.lsp4j.debug.Variable;
+
+import com.github.cameltooling.dap.internal.IdUtils;
+import com.github.cameltooling.dap.internal.types.EventMessage;
+import com.github.cameltooling.dap.internal.types.Header;
+import com.github.cameltooling.dap.internal.types.UnmarshallerEventMessage;
+
+public class CamelMessageScope extends CamelScope {
+	
+	private Map<Integer, List<Header>> headersVariableReferenceToHeaders = new HashMap<>();
+
+	public CamelMessageScope(CamelStackFrame stackframe) {
+		super("Message", stackframe.getName(), IdUtils.getPositiveIntFromHashCode((stackframe.getId()+"@Message@" + stackframe.getName()).hashCode()));
+	}
+	
+	@Override
+	public Set<Variable> createVariables(int variablesReference, ManagedBacklogDebuggerMBean debugger) {
+		Set<Variable> variables = new HashSet<>();
+		if (variablesReference == getVariablesReference()) {
+			String xml = debugger.dumpTracedMessagesAsXml(getBreakpointId(), true);
+			EventMessage eventMessage = new UnmarshallerEventMessage().getUnmarshalledEventMessage(xml);
+			if(eventMessage != null) {
+				variables.add(createVariable("Exchange ID", eventMessage.getExchangeId()));
+				variables.add(createVariable("UID", Long.toString(eventMessage.getUid())));
+				variables.add(createVariable("Body", eventMessage.getMessage().getBody()));
+				Variable headersVariable = new Variable();
+				headersVariable.setName("Headers");
+				headersVariable.setValue("");
+				int headerVarRefId = IdUtils.getPositiveIntFromHashCode((variablesReference+"@Headers@").hashCode());
+				headersVariableReferenceToHeaders.put(headerVarRefId, eventMessage.getMessage().getHeaders());
+				headersVariable.setVariablesReference(headerVarRefId);
+				variables.add(headersVariable);
+			}
+		} else {
+			List<Header> headers = headersVariableReferenceToHeaders.get(variablesReference);
+			if(headers != null) {
+				for (Header header : headers) {
+					variables.add(createVariable(header.getKey(), header.getValue()));
+				}
+			}
+		}
+		return variables;
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/dap/internal/model/CamelProcessorScope.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/CamelProcessorScope.java
@@ -20,35 +20,24 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
-import org.eclipse.lsp4j.debug.Source;
-import org.eclipse.lsp4j.debug.StackFrame;
 import org.eclipse.lsp4j.debug.Variable;
 
-public class CamelStackFrame extends StackFrame {
+import com.github.cameltooling.dap.internal.IdUtils;
 
-	private Set<CamelScope> scopes = new HashSet<>();
+public class CamelProcessorScope extends CamelScope {
 
-	public CamelStackFrame(int frameId, String breakpointId, Source source, Integer line) {
-		setId(frameId);
-		setName(breakpointId);
-		setSource(source);
-		setLine(line);
-	}
-	
-	public Set<CamelScope> createScopes() {
-		scopes.clear();
-		scopes.add(new CamelDebuggerScope(this));
-		scopes.add(new CamelEndpointScope(this));
-		scopes.add(new CamelProcessorScope(this));
-		scopes.add(new CamelExchangeScope(this));
-		scopes.add(new CamelMessageScope(this));
-		return scopes;
+	public CamelProcessorScope(CamelStackFrame stackframe) {
+		super("Processor", stackframe.getName(), IdUtils.getPositiveIntFromHashCode((stackframe.getId()+"@Processor@" + stackframe.getName()).hashCode()));
 	}
 
+	@Override
 	public Set<Variable> createVariables(int variablesReference, ManagedBacklogDebuggerMBean debugger) {
 		Set<Variable> variables = new HashSet<>();
-		for (CamelScope camelScope : scopes) {
-			variables.addAll(camelScope.createVariables(variablesReference, debugger));
+		if (variablesReference == getVariablesReference()) {
+			variables.add(createVariable("Processor Id", getName()));
+			// TODO: variables.add(createVariable("Route Id", connectionManager.getBacklogDebugger().getRouteId(breakpointId)));
+			variables.add(createVariable("Camel Id", debugger.getCamelId()));
+			// TODO: variables.add(createVariable("Completed Exchange", debugger.getCompletedExchanges(breakpointId)));
 		}
 		return variables;
 	}

--- a/src/main/java/com/github/cameltooling/dap/internal/model/CamelScope.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/CamelScope.java
@@ -16,41 +16,48 @@
  */
 package com.github.cameltooling.dap.internal.model;
 
-import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
-import org.eclipse.lsp4j.debug.Source;
-import org.eclipse.lsp4j.debug.StackFrame;
+import org.eclipse.lsp4j.debug.Scope;
 import org.eclipse.lsp4j.debug.Variable;
 
-public class CamelStackFrame extends StackFrame {
+public abstract class CamelScope extends Scope {
 
-	private Set<CamelScope> scopes = new HashSet<>();
+	private String breakpointId;
 
-	public CamelStackFrame(int frameId, String breakpointId, Source source, Integer line) {
-		setId(frameId);
-		setName(breakpointId);
-		setSource(source);
-		setLine(line);
+	protected CamelScope(String name, String breakpointId, int variableRefId) {
+		setName(name);
+		setVariablesReference(variableRefId);
+		this.breakpointId = breakpointId;
+	}
+
+	public String getBreakpointId() {
+		return breakpointId;
 	}
 	
-	public Set<CamelScope> createScopes() {
-		scopes.clear();
-		scopes.add(new CamelDebuggerScope(this));
-		scopes.add(new CamelEndpointScope(this));
-		scopes.add(new CamelProcessorScope(this));
-		scopes.add(new CamelExchangeScope(this));
-		scopes.add(new CamelMessageScope(this));
-		return scopes;
+	public abstract Set<Variable> createVariables(int variablesReference, ManagedBacklogDebuggerMBean debugger);
+	
+	protected Variable createVariable(String variableName, String variableValue) {
+		Variable variable = new Variable();
+		variable.setName(variableName);
+		variable.setValue(variableValue);
+		return variable;
 	}
-
-	public Set<Variable> createVariables(int variablesReference, ManagedBacklogDebuggerMBean debugger) {
-		Set<Variable> variables = new HashSet<>();
-		for (CamelScope camelScope : scopes) {
-			variables.addAll(camelScope.createVariables(variablesReference, debugger));
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (!super.equals(obj)) {
+			return false;
 		}
-		return variables;
+		CamelScope that = (CamelScope) obj;
+		return Objects.equals(this.breakpointId, that.breakpointId);
+	}
+	
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), breakpointId);
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/dap/internal/model/CamelThread.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/CamelThread.java
@@ -17,10 +17,12 @@
 package com.github.cameltooling.dap.internal.model;
 
 import java.util.Objects;
+import java.util.Set;
 
+import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
 import org.eclipse.lsp4j.debug.Source;
-import org.eclipse.lsp4j.debug.StackFrame;
 import org.eclipse.lsp4j.debug.Thread;
+import org.eclipse.lsp4j.debug.Variable;
 
 import com.github.cameltooling.dap.internal.IdUtils;
 import com.github.cameltooling.dap.internal.types.EventMessage;
@@ -28,7 +30,7 @@ import com.github.cameltooling.dap.internal.types.EventMessage;
 public class CamelThread extends Thread {
 
 	private String breakpointId;
-	private StackFrame stackFrame;
+	private CamelStackFrame stackFrame;
 	private EventMessage eventMessage;
 
 	public CamelThread(int threadId, String breakpointId, EventMessage eventMessage, CamelBreakpoint camelBreakpoint) {
@@ -69,7 +71,7 @@ public class CamelThread extends Thread {
 		return breakpointId;
 	}
 
-	public StackFrame getStackFrame() {
+	public CamelStackFrame getStackFrame() {
 		return stackFrame;
 	}
 
@@ -85,4 +87,7 @@ public class CamelThread extends Thread {
 		// TODO : implement update of Thread when same exchange id is suspended 2 times
 	}
 
+	public Set<Variable> createVariables(int variablesReference, ManagedBacklogDebuggerMBean debugger) {
+		return stackFrame.createVariables(variablesReference, debugger);
+	}
 }

--- a/src/test/java/com/github/cameltooling/dap/internal/ResumeSingleThreadTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/ResumeSingleThreadTest.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.engine.DefaultProducerTemplate;
+import org.eclipse.lsp4j.debug.ContinueArguments;
+import org.eclipse.lsp4j.debug.SetBreakpointsArguments;
+import org.eclipse.lsp4j.debug.StoppedEventArguments;
+import org.eclipse.lsp4j.debug.StoppedEventArgumentsReason;
+import org.junit.jupiter.api.Test;
+
+class ResumeSingleThreadTest extends BaseTest {
+
+	@Test
+	void testResume() throws Exception {
+		try (CamelContext context = new DefaultCamelContext()) {
+			String routeId1 = "a-route-id-1";
+			String startEndpointUri1 = "direct:testResume1";
+			String routeId2 = "a-route-id-2";
+			String startEndpointUri2 = "direct:testResume2";
+			context.addRoutes(new RouteBuilder() {
+			
+				@Override
+				public void configure() throws Exception {
+					from(startEndpointUri1)
+						.routeId(routeId1)
+						.log("Log from test 1");  // line number to use from here
+						
+					from(startEndpointUri2)
+						.routeId(routeId2)
+						.log("Log from test 2");  // line number to use from here
+				}
+			});
+			int firstLineNumberToPutBreakpoint = 48;
+			int secondLineNumberToPutBreakpoint = 52;
+			context.start();
+			assertThat(context.isStarted()).isTrue();
+			initDebugger();
+			attach(server);
+			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument(firstLineNumberToPutBreakpoint, secondLineNumberToPutBreakpoint);
+			
+			server.setBreakpoints(setBreakpointsArguments).get();
+			
+			DefaultProducerTemplate producerTemplate = DefaultProducerTemplate.newInstance(context, startEndpointUri1);
+			producerTemplate.start();
+			
+			CompletableFuture<Object> asyncSendBody1 = producerTemplate.asyncSendBody(startEndpointUri1, "a body1");
+			waitBreakpointNotification(1);
+			CompletableFuture<Object> asyncSendBody2 = producerTemplate.asyncSendBody(startEndpointUri2, "a body2");
+			
+			waitBreakpointNotification(2);
+			StoppedEventArguments stoppedEventArgument = clientProxy.getStoppedEventArguments().get(0);
+			assertThat(stoppedEventArgument.getThreadId()).isEqualTo(1);
+			assertThat(stoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
+			assertThat(asyncSendBody1.isDone()).isFalse();
+			
+			StoppedEventArguments secondStoppedEventArgument = clientProxy.getStoppedEventArguments().get(1);
+			assertThat(secondStoppedEventArgument.getThreadId()).isEqualTo(2);
+			assertThat(secondStoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
+			assertThat(asyncSendBody2.isDone()).isFalse();
+			
+			
+			ContinueArguments continueArgs1 = new ContinueArguments();
+			continueArgs1.setThreadId(1);
+			server.continue_(continueArgs1);
+			
+			waitRouteIsDone(asyncSendBody1);
+			assertThat(asyncSendBody2.isDone()).isFalse();
+			
+			ContinueArguments continueArgs2 = new ContinueArguments();
+			continueArgs2.setThreadId(2);
+			server.continue_(continueArgs2);
+			waitRouteIsDone(asyncSendBody2);
+			
+			producerTemplate.stop();
+		}
+	}
+	
+}


### PR DESCRIPTION
It comes with a refactor to have a better scoping of variables. It
really ease reading code as the scope per Exchange becomes important to
be able to deal with as one Exchange is a thread. It will be slower in
terms of performance but it should not have a visible impact unless
there are a lot of breakpoints at the same time, which will anyway won't
be very readable in UI

Signed-off-by: Aurélien Pupier <apupier@redhat.com>