### PR TITLE
FUSETOOLS2-1485 - avoid test flakiness

### DIFF
--- a/src/test/java/com/github/cameltooling/dap/internal/BasicDebugFlowTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/BasicDebugFlowTest.java
@@ -95,9 +95,9 @@ class BasicDebugFlowTest extends BaseTest {
 			
 			assertThat(clientProxy.getAllStacksAndVars()).hasSize(1);
 			StackAndVarOnStopEvent stackAndData = clientProxy.getAllStacksAndVars().get(0);
-			assertThat(stackAndData.getThreads()).hasSize(1);
-			assertThat(stackAndData.getStackFrames()).hasSize(1);
-			assertThat(stackAndData.getScopes()).hasSize(5);
+			await().untilAsserted(() -> assertThat(stackAndData.getThreads()).hasSize(1));
+			await().untilAsserted(() -> assertThat(stackAndData.getStackFrames()).hasSize(1));
+			await().untilAsserted(() -> assertThat(stackAndData.getScopes()).hasSize(5));
 			await("handling of stop event response is finished")
 			 .atMost(Duration.ofSeconds(60))
 			 .until(() -> {


### PR DESCRIPTION
the error message was that the size was 0 and expecting 5 but when
displaying the error message, the list had 5 elements. So was just a
matter of awaiting correctly.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>