### PR TITLE
FUSETOOLS2-1429 - Support stepping - first iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The Camel Debug Server Adapter must use Java Runtime Environment 11+ with `com.s
 - Inspect some variables when breakpoint is hit
 - Stop on hit breakpoint
 - Resume all
+- Stepping when the route definition is in the same file
 - Tested manually with [Eclipse LSP4E](https://github.com/eclipse/lsp4e), see [how-to](https://github.com/camel-tooling/camel-dap-client-eclipse#how-to-use-the-debug-adapter-for-apache-camel)
 - Tested manually with locally built [VS Code Debug Adapter for Apache Camel](https://github.com/camel-tooling/camel-dap-client-vscode), see [how-to](https://github.com/camel-tooling/camel-dap-client-vscode#how-to-use-it)
 

--- a/src/main/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServer.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServer.java
@@ -35,6 +35,7 @@ import org.eclipse.lsp4j.debug.ContinueArguments;
 import org.eclipse.lsp4j.debug.ContinueResponse;
 import org.eclipse.lsp4j.debug.DisconnectArguments;
 import org.eclipse.lsp4j.debug.InitializeRequestArguments;
+import org.eclipse.lsp4j.debug.NextArguments;
 import org.eclipse.lsp4j.debug.Scope;
 import org.eclipse.lsp4j.debug.ScopesArguments;
 import org.eclipse.lsp4j.debug.ScopesResponse;
@@ -195,7 +196,7 @@ public class CamelDebugAdapterServer implements IDebugProtocolServer {
 		int threadId = args.getThreadId();
 		if (threadId != 0) {
 			response.setAllThreadsContinued(Boolean.FALSE);
-			Optional<CamelThread> findAny = connectionManager.getCamelThreads().stream().filter(camelThread -> camelThread.getId() == threadId).findAny();
+			Optional<CamelThread> findAny = findThread(threadId);
 			if (findAny.isPresent()) {
 				CamelThread camelThread = findAny.get();
 				connectionManager.resume(camelThread);
@@ -205,6 +206,21 @@ public class CamelDebugAdapterServer implements IDebugProtocolServer {
 			response.setAllThreadsContinued(Boolean.TRUE);
 		}
 		return CompletableFuture.completedFuture(response);
+	}
+
+	private Optional<CamelThread> findThread(int threadId) {
+		return connectionManager.getCamelThreads().stream().filter(camelThread -> camelThread.getId() == threadId).findAny();
+	}
+	
+	@Override
+	public CompletableFuture<Void> next(NextArguments args) {
+		int threadId = args.getThreadId();
+		Optional<CamelThread> findAny = findThread(threadId);
+		if (findAny.isPresent()) {
+			CamelThread camelThread = findAny.get();
+			connectionManager.next(camelThread);
+		}
+		return CompletableFuture.completedFuture(null);
 	}
 	
 	@Override

--- a/src/main/java/com/github/cameltooling/dap/internal/model/CamelThread.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/CamelThread.java
@@ -38,11 +38,12 @@ public class CamelThread extends Thread {
 		setName(eventMessage.getExchangeId());
 		this.breakpointId = breakpointId;
 		this.eventMessage = eventMessage;
-		// TODO: provide a better hashcode for stackframe containing the camelcontext too
-		int frameId = IdUtils.getPositiveIntFromHashCode(breakpointId.hashCode());
+		// TODO: provide a better hashcode for stackframe containing the camelcontext
+		// too
+		int frameId = IdUtils.getPositiveIntFromHashCode(threadId + breakpointId.hashCode());
 		Source source = null;
 		Integer line = null;
-		if(camelBreakpoint != null) {
+		if (camelBreakpoint != null) {
 			source = camelBreakpoint.getSource();
 			line = camelBreakpoint.getLine();
 		} else {
@@ -61,7 +62,7 @@ public class CamelThread extends Thread {
 				&& Objects.equals(this.eventMessage, that.eventMessage)
 				&& Objects.equals(this.stackFrame, that.stackFrame);
 	}
-	
+
 	@Override
 	public int hashCode() {
 		return Objects.hash(super.hashCode(), breakpointId, eventMessage, stackFrame);
@@ -79,15 +80,8 @@ public class CamelThread extends Thread {
 		return eventMessage != null ? eventMessage.getExchangeId() : null;
 	}
 
-	public void update(String breakpointId, EventMessage eventMessage) {
-		if(!eventMessage.getExchangeId().equals(this.eventMessage.getExchangeId())) {
-			throw new IllegalArgumentException("The Camel Thread must be reused only for same Exchange Id");
-		}
-		this.breakpointId = breakpointId;
-		// TODO : implement update of Thread when same exchange id is suspended 2 times
-	}
-
 	public Set<Variable> createVariables(int variablesReference, ManagedBacklogDebuggerMBean debugger) {
 		return stackFrame.createVariables(variablesReference, debugger);
 	}
+
 }

--- a/src/test/java/com/github/cameltooling/dap/internal/NextStepTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/NextStepTest.java
@@ -1,0 +1,201 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.engine.DefaultProducerTemplate;
+import org.eclipse.lsp4j.debug.ContinueArguments;
+import org.eclipse.lsp4j.debug.NextArguments;
+import org.eclipse.lsp4j.debug.SetBreakpointsArguments;
+import org.eclipse.lsp4j.debug.StoppedEventArguments;
+import org.eclipse.lsp4j.debug.StoppedEventArgumentsReason;
+import org.junit.jupiter.api.Test;
+
+class NextStepTest extends BaseTest {
+	
+	private static final int DEFAULT_VARIABLES_NUMBER = 19;
+
+	@Test
+	void testSteppingInsideRoute() throws Exception {
+		try (CamelContext context = new DefaultCamelContext()) {
+			String routeId = "a-route-id";
+			String startEndpointUri = "direct:testResume";
+			context.addRoutes(new RouteBuilder() {
+			
+				@Override
+				public void configure() throws Exception {
+					from(startEndpointUri)
+						.routeId(routeId)
+						.log("Log from test")  // line number to use from here
+						.log("second log")
+						.log("last log");
+				}
+			});
+			int firstLineNumberToPutBreakpoint = 50;
+			context.start();
+			assertThat(context.isStarted()).isTrue();
+			initDebugger();
+			attach(server);
+			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument(firstLineNumberToPutBreakpoint);
+			
+			server.setBreakpoints(setBreakpointsArguments).get();
+			
+			DefaultProducerTemplate producerTemplate = DefaultProducerTemplate.newInstance(context, startEndpointUri);
+			producerTemplate.start();
+			
+			CompletableFuture<Object> asyncSendBody = producerTemplate.asyncSendBody(startEndpointUri, "a body");
+			
+			waitBreakpointNotification(1);
+			StoppedEventArguments stoppedEventArgument = clientProxy.getStoppedEventArguments().get(0);
+			assertThat(stoppedEventArgument.getThreadId()).isEqualTo(1);
+			assertThat(stoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
+			assertThat(asyncSendBody.isDone()).isFalse();
+			await().untilAsserted(() -> assertThat(clientProxy.getAllStacksAndVars().get(0).getVariables()).hasSize(DEFAULT_VARIABLES_NUMBER));
+			
+			NextArguments nextArguments = new NextArguments();
+			nextArguments.setThreadId(1);
+			server.next(nextArguments);
+			
+			waitBreakpointNotification(2);
+			StoppedEventArguments secondStoppedEventArgument = clientProxy.getStoppedEventArguments().get(1);
+			assertThat(secondStoppedEventArgument.getThreadId()).isEqualTo(1);
+			assertThat(secondStoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
+			assertThat(asyncSendBody.isDone()).isFalse();
+			await().untilAsserted(() -> assertThat(clientProxy.getAllStacksAndVars().get(1).getVariables()).hasSize(DEFAULT_VARIABLES_NUMBER));
+			server.continue_(new ContinueArguments());
+			
+			waitRouteIsDone(asyncSendBody);
+			
+			assertThat(server.threads().get().getThreads()).isEmpty();
+			
+			producerTemplate.stop();
+		}
+	}
+	
+	@Test
+	void testSteppingAtEndOfRoute() throws Exception {
+		try (CamelContext context = new DefaultCamelContext()) {
+			String routeId = "a-route-id";
+			String startEndpointUri = "direct:testResume";
+			context.addRoutes(new RouteBuilder() {
+			
+				@Override
+				public void configure() throws Exception {
+					from(startEndpointUri)
+						.routeId(routeId)
+						.log("Log from test")  // line number to use from here
+						.log("second log")
+						.log("last log");
+				}
+			});
+			int firstLineNumberToPutBreakpoint = 109;
+			context.start();
+			assertThat(context.isStarted()).isTrue();
+			initDebugger();
+			attach(server);
+			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument(firstLineNumberToPutBreakpoint);
+			
+			server.setBreakpoints(setBreakpointsArguments).get();
+			
+			DefaultProducerTemplate producerTemplate = DefaultProducerTemplate.newInstance(context, startEndpointUri);
+			producerTemplate.start();
+			
+			CompletableFuture<Object> asyncSendBody = producerTemplate.asyncSendBody(startEndpointUri, "a body");
+			
+			waitBreakpointNotification(1);
+			StoppedEventArguments stoppedEventArgument = clientProxy.getStoppedEventArguments().get(0);
+			assertThat(stoppedEventArgument.getThreadId()).isEqualTo(1);
+			assertThat(stoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
+			assertThat(asyncSendBody.isDone()).isFalse();
+			await().untilAsserted(() -> assertThat(clientProxy.getAllStacksAndVars().get(0).getVariables()).hasSize(DEFAULT_VARIABLES_NUMBER));
+			
+			NextArguments nextArguments = new NextArguments();
+			nextArguments.setThreadId(1);
+			server.next(nextArguments);
+			
+			waitRouteIsDone(asyncSendBody);
+			
+			assertThat(server.threads().get().getThreads()).isEmpty();
+			
+			producerTemplate.stop();
+		}
+	}
+	
+	@Test
+	void testSteppingWithExistingBreakpoint() throws Exception {
+		try (CamelContext context = new DefaultCamelContext()) {
+			String routeId = "a-route-id";
+			String startEndpointUri = "direct:testResume";
+			context.addRoutes(new RouteBuilder() {
+			
+				@Override
+				public void configure() throws Exception {
+					from(startEndpointUri)
+						.routeId(routeId)
+						.log("Log from test")  // line number to use from here
+						.log("second log")
+						.log("last log");
+				}
+			});
+			int firstLineNumberToPutBreakpoint = 156;
+			context.start();
+			assertThat(context.isStarted()).isTrue();
+			initDebugger();
+			attach(server);
+			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument(firstLineNumberToPutBreakpoint, firstLineNumberToPutBreakpoint + 1);
+			
+			server.setBreakpoints(setBreakpointsArguments).get();
+			
+			DefaultProducerTemplate producerTemplate = DefaultProducerTemplate.newInstance(context, startEndpointUri);
+			producerTemplate.start();
+			
+			CompletableFuture<Object> asyncSendBody = producerTemplate.asyncSendBody(startEndpointUri, "a body");
+			
+			waitBreakpointNotification(1);
+			StoppedEventArguments stoppedEventArgument = clientProxy.getStoppedEventArguments().get(0);
+			assertThat(stoppedEventArgument.getThreadId()).isEqualTo(1);
+			assertThat(stoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
+			assertThat(asyncSendBody.isDone()).isFalse();
+			await().untilAsserted(() -> assertThat(clientProxy.getAllStacksAndVars().get(0).getVariables()).hasSize(DEFAULT_VARIABLES_NUMBER));
+			
+			NextArguments nextArguments = new NextArguments();
+			nextArguments.setThreadId(1);
+			server.next(nextArguments);
+			
+			waitBreakpointNotification(2);
+			StoppedEventArguments secondStoppedEventArgument = clientProxy.getStoppedEventArguments().get(1);
+			assertThat(secondStoppedEventArgument.getThreadId()).isEqualTo(1);
+			assertThat(secondStoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
+			assertThat(asyncSendBody.isDone()).isFalse();
+			await().untilAsserted(() -> assertThat(clientProxy.getAllStacksAndVars().get(1).getVariables()).hasSize(DEFAULT_VARIABLES_NUMBER));
+			server.continue_(new ContinueArguments());
+			
+			waitRouteIsDone(asyncSendBody);
+			
+			assertThat(server.threads().get().getThreads()).isEmpty();
+			
+			producerTemplate.stop();
+		}
+	}
+}


### PR DESCRIPTION
- Keeping the same Thread id as it is the same exchange
- Need to detect programmatically when it is the last endpoint of the
route. In this case, we need to clear Thread and send a terminated
thread event
- For now supports only when the route definition is written in a single
file. (no easy way to lookup for the exact source file on the
filesystem) Reported https://issues.redhat.com/browse/FUSETOOLS2-1488

