### PR TITLE
FUSETOOLS2-1493 - avoid test flakiness

### DIFF
--- a/src/test/java/com/github/cameltooling/dap/internal/BaseTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/BaseTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.AfterEach;
 
 public abstract class BaseTest {
 
+	protected static final int DEFAULT_VARIABLES_NUMBER = 19;
 	protected CamelDebugAdapterServer server;
 	protected DummyCamelDebugClient clientProxy;
 
@@ -108,6 +109,16 @@ public abstract class BaseTest {
 		clientProxy = new DummyCamelDebugClient(server);
 		server.connect(clientProxy);
 		return server.initialize(new InitializeRequestArguments());
+	}
+
+	protected void awaitAllVariablesFilled(int indexOfAllStacksAndVars, int variablesNumber) {
+		await().untilAsserted(() -> {
+			assertThat(clientProxy.getAllStacksAndVars().get(indexOfAllStacksAndVars).getVariables()).hasSize(variablesNumber);
+		});
+	}
+	
+	protected void awaitAllVariablesFilled(int indexOfAllStacksAndVars) {
+		awaitAllVariablesFilled(indexOfAllStacksAndVars, DEFAULT_VARIABLES_NUMBER);
 	}
 
 }

--- a/src/test/java/com/github/cameltooling/dap/internal/NextStepTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/NextStepTest.java
@@ -17,7 +17,6 @@
 package com.github.cameltooling.dap.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -34,8 +33,6 @@ import org.junit.jupiter.api.Test;
 
 class NextStepTest extends BaseTest {
 	
-	private static final int DEFAULT_VARIABLES_NUMBER = 19;
-
 	@Test
 	void testSteppingInsideRoute() throws Exception {
 		try (CamelContext context = new DefaultCamelContext()) {
@@ -52,7 +49,7 @@ class NextStepTest extends BaseTest {
 						.log("last log");
 				}
 			});
-			int firstLineNumberToPutBreakpoint = 50;
+			int firstLineNumberToPutBreakpoint = 47;
 			context.start();
 			assertThat(context.isStarted()).isTrue();
 			initDebugger();
@@ -71,7 +68,7 @@ class NextStepTest extends BaseTest {
 			assertThat(stoppedEventArgument.getThreadId()).isEqualTo(1);
 			assertThat(stoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
 			assertThat(asyncSendBody.isDone()).isFalse();
-			await().untilAsserted(() -> assertThat(clientProxy.getAllStacksAndVars().get(0).getVariables()).hasSize(DEFAULT_VARIABLES_NUMBER));
+			awaitAllVariablesFilled(0);
 			
 			NextArguments nextArguments = new NextArguments();
 			nextArguments.setThreadId(1);
@@ -82,7 +79,7 @@ class NextStepTest extends BaseTest {
 			assertThat(secondStoppedEventArgument.getThreadId()).isEqualTo(1);
 			assertThat(secondStoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
 			assertThat(asyncSendBody.isDone()).isFalse();
-			await().untilAsserted(() -> assertThat(clientProxy.getAllStacksAndVars().get(1).getVariables()).hasSize(DEFAULT_VARIABLES_NUMBER));
+			awaitAllVariablesFilled(1);
 			server.continue_(new ContinueArguments());
 			
 			waitRouteIsDone(asyncSendBody);
@@ -92,7 +89,7 @@ class NextStepTest extends BaseTest {
 			producerTemplate.stop();
 		}
 	}
-	
+
 	@Test
 	void testSteppingAtEndOfRoute() throws Exception {
 		try (CamelContext context = new DefaultCamelContext()) {
@@ -109,7 +106,7 @@ class NextStepTest extends BaseTest {
 						.log("last log");
 				}
 			});
-			int firstLineNumberToPutBreakpoint = 109;
+			int firstLineNumberToPutBreakpoint = 106;
 			context.start();
 			assertThat(context.isStarted()).isTrue();
 			initDebugger();
@@ -128,7 +125,7 @@ class NextStepTest extends BaseTest {
 			assertThat(stoppedEventArgument.getThreadId()).isEqualTo(1);
 			assertThat(stoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
 			assertThat(asyncSendBody.isDone()).isFalse();
-			await().untilAsserted(() -> assertThat(clientProxy.getAllStacksAndVars().get(0).getVariables()).hasSize(DEFAULT_VARIABLES_NUMBER));
+			awaitAllVariablesFilled(0);
 			
 			NextArguments nextArguments = new NextArguments();
 			nextArguments.setThreadId(1);
@@ -158,7 +155,7 @@ class NextStepTest extends BaseTest {
 						.log("last log");
 				}
 			});
-			int firstLineNumberToPutBreakpoint = 156;
+			int firstLineNumberToPutBreakpoint = 153;
 			context.start();
 			assertThat(context.isStarted()).isTrue();
 			initDebugger();
@@ -177,7 +174,7 @@ class NextStepTest extends BaseTest {
 			assertThat(stoppedEventArgument.getThreadId()).isEqualTo(1);
 			assertThat(stoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
 			assertThat(asyncSendBody.isDone()).isFalse();
-			await().untilAsserted(() -> assertThat(clientProxy.getAllStacksAndVars().get(0).getVariables()).hasSize(DEFAULT_VARIABLES_NUMBER));
+			awaitAllVariablesFilled(0);
 			
 			NextArguments nextArguments = new NextArguments();
 			nextArguments.setThreadId(1);
@@ -188,7 +185,7 @@ class NextStepTest extends BaseTest {
 			assertThat(secondStoppedEventArgument.getThreadId()).isEqualTo(1);
 			assertThat(secondStoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
 			assertThat(asyncSendBody.isDone()).isFalse();
-			await().untilAsserted(() -> assertThat(clientProxy.getAllStacksAndVars().get(1).getVariables()).hasSize(DEFAULT_VARIABLES_NUMBER));
+			awaitAllVariablesFilled(1);
 			server.continue_(new ContinueArguments());
 			
 			waitRouteIsDone(asyncSendBody);

--- a/src/test/java/com/github/cameltooling/dap/internal/RemoveBreakpointTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/RemoveBreakpointTest.java
@@ -76,6 +76,8 @@ class RemoveBreakpointTest extends BaseTest {
 		
 		assertThat(asyncSendBody.isDone()).isFalse();
 		
+		awaitAllVariablesFilled(0);
+		
 		assertThat(clientProxy.getAllStacksAndVars()).hasSize(1);
 		StackAndVarOnStopEvent stackAndData = clientProxy.getAllStacksAndVars().get(0);
 		assertThat(stackAndData.getThreads()).hasSize(1);

--- a/src/test/java/com/github/cameltooling/dap/internal/ResumeAllTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/ResumeAllTest.java
@@ -17,7 +17,6 @@
 package com.github.cameltooling.dap.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -49,7 +48,7 @@ class ResumeAllTest extends BaseTest {
 						.log("Log from test");  // line number to use from here
 				}
 			});
-			int lineNumberToPutBreakpoint = 49;
+			int lineNumberToPutBreakpoint = 48;
 			context.start();
 			assertThat(context.isStarted()).isTrue();
 			initDebugger();
@@ -68,7 +67,7 @@ class ResumeAllTest extends BaseTest {
 			StoppedEventArguments stoppedEventArgument = clientProxy.getStoppedEventArguments().get(index);
 			assertThat(stoppedEventArgument.getThreadId()).isEqualTo(1);
 			assertThat(stoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
-			waitForBodyVariable(0);
+			awaitAllVariablesFilled(0);
 			Variable bodyVariable1 = findBodyVariableAtIndex(index).get();
 			assertThat(bodyVariable1.getValue()).isEqualTo("a body");
 			
@@ -84,19 +83,12 @@ class ResumeAllTest extends BaseTest {
 			
 			waitBreakpointNotification(2);
 			
-			waitForBodyVariable(1);
+			awaitAllVariablesFilled(1);
 			Variable bodyVariable2 = findBodyVariableAtIndex(1).get();
 			assertThat(bodyVariable2.getValue()).isEqualTo("a body 2");
 			
 			producerTemplate.stop();
 		}
-	}
-
-	private void waitForBodyVariable(int index) {
-		await("Wait for body variable to be filled up")
-			.until(() -> {
-				return findBodyVariableAtIndex(index).isPresent();
-			});
 	}
 
 	private Optional<Variable> findBodyVariableAtIndex(int index) {
@@ -118,7 +110,7 @@ class ResumeAllTest extends BaseTest {
 						.log("second log");
 				}
 			});
-			int firstLineNumberToPutBreakpoint = 117;
+			int firstLineNumberToPutBreakpoint = 109;
 			int secondLineNumberToPutBreakpoint = firstLineNumberToPutBreakpoint + 1;
 			context.start();
 			assertThat(context.isStarted()).isTrue();
@@ -138,6 +130,7 @@ class ResumeAllTest extends BaseTest {
 			assertThat(stoppedEventArgument.getThreadId()).isEqualTo(1);
 			assertThat(stoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
 			assertThat(asyncSendBody.isDone()).isFalse();
+			awaitAllVariablesFilled(0);
 			server.continue_(new ContinueArguments());
 			
 			waitBreakpointNotification(2);
@@ -145,6 +138,7 @@ class ResumeAllTest extends BaseTest {
 			assertThat(secondStoppedEventArgument.getThreadId()).isEqualTo(2);
 			assertThat(secondStoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
 			assertThat(asyncSendBody.isDone()).isFalse();
+			awaitAllVariablesFilled(1);
 			server.continue_(new ContinueArguments());
 			
 			waitRouteIsDone(asyncSendBody);

--- a/src/test/java/com/github/cameltooling/dap/internal/ResumeSingleThreadTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/ResumeSingleThreadTest.java
@@ -67,9 +67,11 @@ class ResumeSingleThreadTest extends BaseTest {
 			
 			CompletableFuture<Object> asyncSendBody1 = producerTemplate.asyncSendBody(startEndpointUri1, "a body1");
 			waitBreakpointNotification(1);
+			awaitAllVariablesFilled(0);
 			CompletableFuture<Object> asyncSendBody2 = producerTemplate.asyncSendBody(startEndpointUri2, "a body2");
 			
 			waitBreakpointNotification(2);
+			awaitAllVariablesFilled(1, DEFAULT_VARIABLES_NUMBER *2);
 			StoppedEventArguments stoppedEventArgument = clientProxy.getStoppedEventArguments().get(0);
 			assertThat(stoppedEventArgument.getThreadId()).isEqualTo(1);
 			assertThat(stoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);


### PR DESCRIPTION
In the test, the dummy client is not really Thread-safe. Try to wait
that it finishes to collect all datas, before calling a resume/continue.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>