### PR TITLE
FUSETOOLS2-1495 - avoid ConcurrentModificationException

### DIFF
--- a/src/main/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServer.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServer.java
@@ -183,7 +183,7 @@ public class CamelDebugAdapterServer implements IDebugProtocolServer {
 		Set<Variable> variables = new HashSet<>();
 		
 		ManagedBacklogDebuggerMBean debugger = connectionManager.getBacklogDebugger();
-		for (CamelThread camelThread : connectionManager.getCamelThreads()) {
+		for (CamelThread camelThread : new HashSet<CamelThread>(connectionManager.getCamelThreads())) {
 			variables.addAll(camelThread.createVariables(variablesReference, debugger));
 		}
 		response.setVariables(variables.toArray(new Variable[variables.size()]));


### PR DESCRIPTION
use a copy of the Set of threads when trying to access the list of
variables

Signed-off-by: Aurélien Pupier <apupier@redhat.com>