### PR TITLE
FUSETOOLS2-1510 - Provide a more resilient way to indicate line number

### DIFF
--- a/src/test/java/com/github/cameltooling/dap/internal/BasicDebugFlowTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/BasicDebugFlowTest.java
@@ -61,7 +61,7 @@ class BasicDebugFlowTest extends BaseTest {
 						.setHeader("header2", constant("value of header 2"))
 						.setProperty("property1", constant("value of property 1"))
 						.setProperty("property2", constant("value of property 2"))
-						.log("Log from test").id(logEndpointId); // line number to use from here
+						.log("Log from test").id(logEndpointId); // XXX-breakpoint-XXX
 				}
 			});
 			int lineNumberToPutBreakpoint = 64;
@@ -69,7 +69,7 @@ class BasicDebugFlowTest extends BaseTest {
 			assertThat(context.isStarted()).isTrue();
 			initDebugger();
 			attach(server);
-			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument(lineNumberToPutBreakpoint);
+			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint-XXX");
 			
 			SetBreakpointsResponse response = server.setBreakpoints(setBreakpointsArguments).get();
 			

--- a/src/test/java/com/github/cameltooling/dap/internal/MultipleThreadsTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/MultipleThreadsTest.java
@@ -43,17 +43,17 @@ class MultipleThreadsTest extends BaseTest {
 				@Override
 				public void configure() throws Exception {
 					from(startEndpointUri1)
-						.log("Log from test 1");  // line number to use from here
+						.log("Log from test 1");  // XXX-breakpoint1-XXX
 					
 					from(startEndpointUri2)
-						.log("Log from test 2");  // line number to use from here
+						.log("Log from test 2");  // XXX-breakpoint2-XXX
 				}
 			});
 			context.start();
 			assertThat(context.isStarted()).isTrue();
 			initDebugger();
 			attach(server);
-			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument(46, 49);
+			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint1-XXX", "XXX-breakpoint2-XXX");
 			
 			server.setBreakpoints(setBreakpointsArguments).get();
 			

--- a/src/test/java/com/github/cameltooling/dap/internal/NextStepTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/NextStepTest.java
@@ -44,17 +44,16 @@ class NextStepTest extends BaseTest {
 				public void configure() throws Exception {
 					from(startEndpointUri)
 						.routeId(routeId)
-						.log("Log from test")  // line number to use from here
+						.log("Log from test")  // XXX-breakpoint-step-inside-XXX
 						.log("second log")
 						.log("last log");
 				}
 			});
-			int firstLineNumberToPutBreakpoint = 47;
 			context.start();
 			assertThat(context.isStarted()).isTrue();
 			initDebugger();
 			attach(server);
-			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument(firstLineNumberToPutBreakpoint);
+			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint-step-inside-XXX");
 			
 			server.setBreakpoints(setBreakpointsArguments).get();
 			
@@ -101,17 +100,16 @@ class NextStepTest extends BaseTest {
 				public void configure() throws Exception {
 					from(startEndpointUri)
 						.routeId(routeId)
-						.log("Log from test")  // line number to use from here
+						.log("Log from test")  
 						.log("second log")
-						.log("last log");
+						.log("last log"); // XXX-breakpoint-step-at-end-XXX
 				}
 			});
-			int firstLineNumberToPutBreakpoint = 106;
 			context.start();
 			assertThat(context.isStarted()).isTrue();
 			initDebugger();
 			attach(server);
-			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument(firstLineNumberToPutBreakpoint);
+			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint-step-at-end-XXX");
 			
 			server.setBreakpoints(setBreakpointsArguments).get();
 			
@@ -150,17 +148,16 @@ class NextStepTest extends BaseTest {
 				public void configure() throws Exception {
 					from(startEndpointUri)
 						.routeId(routeId)
-						.log("Log from test")  // line number to use from here
-						.log("second log")
+						.log("Log from test")  // XXX-breakpoint-step-with-existing-breakpoint-XXX
+						.log("second log") // XXX-breakpoint-step-with-existing-breakpoint2-XXX
 						.log("last log");
 				}
 			});
-			int firstLineNumberToPutBreakpoint = 153;
 			context.start();
 			assertThat(context.isStarted()).isTrue();
 			initDebugger();
 			attach(server);
-			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument(firstLineNumberToPutBreakpoint, firstLineNumberToPutBreakpoint + 1);
+			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint-step-with-existing-breakpoint-XXX", "XXX-breakpoint-step-with-existing-breakpoint2-XXX");
 			
 			server.setBreakpoints(setBreakpointsArguments).get();
 			

--- a/src/test/java/com/github/cameltooling/dap/internal/RemoveBreakpointTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/RemoveBreakpointTest.java
@@ -41,15 +41,14 @@ class RemoveBreakpointTest extends BaseTest {
 				@Override
 				public void configure() throws Exception {
 					from(fromUri)
-						.log("Log from test"); // line number to use from here
+						.log("Log from test"); // XXX-breakpoint-XXX
 				}
 			});
-			int lineNumberToPutBreakpoint = 44;
 			context.start();
 			assertThat(context.isStarted()).isTrue();
 			initDebugger();
 			attach(server);
-			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument(lineNumberToPutBreakpoint);
+			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint-XXX");
 			server.setBreakpoints(setBreakpointsArguments).get();
 			
 			DefaultProducerTemplate producerTemplate = DefaultProducerTemplate.newInstance(context, fromUri);

--- a/src/test/java/com/github/cameltooling/dap/internal/ResumeAllTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/ResumeAllTest.java
@@ -45,15 +45,14 @@ class ResumeAllTest extends BaseTest {
 				public void configure() throws Exception {
 					from(startEndpointUri)
 						.routeId(routeId)
-						.log("Log from test");  // line number to use from here
+						.log("Log from test");  // XXX-breakpoint-another-route-instance-XXX
 				}
 			});
-			int lineNumberToPutBreakpoint = 48;
 			context.start();
 			assertThat(context.isStarted()).isTrue();
 			initDebugger();
 			attach(server);
-			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument(lineNumberToPutBreakpoint);
+			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint-another-route-instance-XXX");
 			
 			server.setBreakpoints(setBreakpointsArguments).get();
 			
@@ -106,17 +105,15 @@ class ResumeAllTest extends BaseTest {
 				public void configure() throws Exception {
 					from(startEndpointUri)
 						.routeId(routeId)
-						.log("Log from test")  // line number to use from here
-						.log("second log");
+						.log("Log from test")  // XXX-breakpoint-same-route-instance-XXX
+						.log("second log"); // XXX-breakpoint-same-route-instance-2-XXX
 				}
 			});
-			int firstLineNumberToPutBreakpoint = 109;
-			int secondLineNumberToPutBreakpoint = firstLineNumberToPutBreakpoint + 1;
 			context.start();
 			assertThat(context.isStarted()).isTrue();
 			initDebugger();
 			attach(server);
-			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument(firstLineNumberToPutBreakpoint, secondLineNumberToPutBreakpoint);
+			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint-same-route-instance-XXX", "XXX-breakpoint-same-route-instance-2-XXX");
 			
 			server.setBreakpoints(setBreakpointsArguments).get();
 			

--- a/src/test/java/com/github/cameltooling/dap/internal/ResumeSingleThreadTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/ResumeSingleThreadTest.java
@@ -45,20 +45,18 @@ class ResumeSingleThreadTest extends BaseTest {
 				public void configure() throws Exception {
 					from(startEndpointUri1)
 						.routeId(routeId1)
-						.log("Log from test 1");  // line number to use from here
+						.log("Log from test 1");  // XXX-breakpoint1-XXX
 						
 					from(startEndpointUri2)
 						.routeId(routeId2)
-						.log("Log from test 2");  // line number to use from here
+						.log("Log from test 2");  // XXX-breakpoint2-XXX
 				}
 			});
-			int firstLineNumberToPutBreakpoint = 48;
-			int secondLineNumberToPutBreakpoint = 52;
 			context.start();
 			assertThat(context.isStarted()).isTrue();
 			initDebugger();
 			attach(server);
-			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument(firstLineNumberToPutBreakpoint, secondLineNumberToPutBreakpoint);
+			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint1-XXX", "XXX-breakpoint2-XXX");
 			
 			server.setBreakpoints(setBreakpointsArguments).get();
 			


### PR DESCRIPTION
of breakpoint in test of Camel DAP

now using a marker, so when modifying the file, no more need to update
all breakpoints line.

Nota: it helped also to spot an error in one test where the incorrect
lien was specific as comment and incorrect sourcePath provided in teh
tests (without incidence to runtime)