### PR TITLE
FUSETOOLS2-1439 - provide basic test for Yaml route

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ The Camel Debug Server Adapter must use Java Runtime Environment 11+ with `com.s
 
 - Local only
 - Attach only
-- Java DSL (not tested with xml and Yaml even if it should work)
+- Java and Yaml DSL (not tested with xml even if it should work)
+  - specific note for yaml: the breakpoint must be set on the from/to line. Not on the Camel URI line.
 - Single context
 - Add and remove breakpoint
 - Inspect some variables when breakpoint is hit

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-yaml-dsl</artifactId>
+			<version>${version.camel}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
 			<version>4.1.1</version>

--- a/src/test/java/com/github/cameltooling/dap/internal/BaseTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/BaseTest.java
@@ -88,11 +88,24 @@ public abstract class BaseTest {
 		return bodyVariable;
 	}
 
+	/**
+	 * @param markersToPutBreakpoint
+	 * 
+	 * It is using the current class as sourceFile
+	 * 
+	 * @return
+	 * @throws FileNotFoundException
+	 */
 	protected SetBreakpointsArguments createSetBreakpointArgument(String... markersToPutBreakpoint)
+			throws FileNotFoundException {
+		File sourceFile = new File("src/test/java/" + getClass().getName().replaceAll("\\.", "/") + ".java");
+		return createSetBreakpointArgument(sourceFile, markersToPutBreakpoint);
+	}
+
+	protected SetBreakpointsArguments createSetBreakpointArgument(File sourceFile, String... markersToPutBreakpoint)
 			throws FileNotFoundException {
 		SetBreakpointsArguments setBreakpointsArguments = new SetBreakpointsArguments();
 		Source source = new Source();
-		File sourceFile = new File("src/test/java/" + getClass().getName().replaceAll("\\.", "/") + ".java");
 		String pathToItself = sourceFile.getAbsolutePath();
 		source.setPath(pathToItself);
 		setBreakpointsArguments.setSource(source);

--- a/src/test/java/com/github/cameltooling/dap/internal/BasicDebugForJavaTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/BasicDebugForJavaTest.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal;
+
+import java.io.FileNotFoundException;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.eclipse.lsp4j.debug.SetBreakpointsArguments;
+
+public class BasicDebugForJavaTest extends BasicDebugFlowTest {
+
+	@Override
+	protected void registerRouteToTest(CamelContext context, String routeId, String logEndpointId) throws Exception {
+		context.addRoutes(new RouteBuilder() {
+		
+			@Override
+			public void configure() throws Exception {
+				from("direct:testSetBreakpoint")
+					.routeId(routeId)
+					.setHeader("header1", constant("value of header 1"))
+					.setHeader("header2", constant("value of header 2"))
+					.setProperty("property1", constant("value of property 1"))
+					.setProperty("property2", constant("value of property 2"))
+					.log("Log from test").id(logEndpointId); // XXX-breakpoint-XXX
+			}
+		});
+	}
+	
+	@Override
+	protected SetBreakpointsArguments createSetBreakpointArgument() throws FileNotFoundException {
+		return createSetBreakpointArgument("XXX-breakpoint-XXX");
+	}
+
+}

--- a/src/test/java/com/github/cameltooling/dap/internal/BasicDebugForYamlTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/BasicDebugForYamlTest.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ExtendedCamelContext;
+import org.apache.camel.spi.Resource;
+import org.eclipse.lsp4j.debug.SetBreakpointsArguments;
+
+class BasicDebugForYamlTest extends BasicDebugFlowTest {
+	
+	File routeForTest;
+	
+	@Override
+	protected void registerRouteToTest(CamelContext context, String routeId, String logEndpointId) throws Exception {
+		ExtendedCamelContext ecc = context.adapt(ExtendedCamelContext.class);
+		Resource resource = ecc.getResourceLoader().resolveResource("/basic.yaml");
+		routeForTest = new File(resource.getURI());
+		ecc.getRoutesLoader().loadRoutes(resource);
+	}
+	
+	@Override
+	protected SetBreakpointsArguments createSetBreakpointArgument() throws FileNotFoundException {
+		return createSetBreakpointArgument(routeForTest, "XXX-breakpoint-XXX");
+	}
+	
+}

--- a/src/test/resources/basic.yaml
+++ b/src/test/resources/basic.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/apache/camel/camel-3.15.0/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/camel-yaml-dsl.json
+- route:
+    id: a-route-id
+    from:
+      uri: direct:testSetBreakpoint
+      steps:
+        - setHeader:
+            name: header1
+            expression:
+              constant: value of header 1
+        - setHeader:
+            name: header2
+            expression:
+              constant: value of header 2
+        - setProperty:
+            name: property1
+            expression:
+              constant: value of property 1
+        - setProperty:
+            name: property2
+            expression:
+              constant: value of property 2
+        - to: # XXX-breakpoint-XXX
+            uri: log:Log From Test
+            id: testBasicFlow-log-id


### PR DESCRIPTION
- the basic test covering the most common use case is now launched with
both Java and Yaml DSL
- not provided a yaml version for other tests, there shouldn't be
something specific to it for now. It would be nice in the future but I
think it already gives enough confidence for now having "just" the most
common scenario covered.

![yamlDebugger-eclipse](https://user-images.githubusercontent.com/1105127/153886663-5ef1b29b-19db-4ca2-9357-6f3e9bc0a590.gif)
![yamlDebugger-VSCode](https://user-images.githubusercontent.com/1105127/153897295-9c45cfb5-341c-41d6-8ccf-c369ab376b0d.gif)

