### PR TITLE
FUSETOOLS2-1438 - provide test for basic flow with xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ The Camel Debug Server Adapter must use Java Runtime Environment 11+ with `com.s
 
 - Local only
 - Attach only
-- Java and Yaml DSL (not tested with xml even if it should work)
-  - specific note for yaml: the breakpoint must be set on the from/to line. Not on the Camel URI line.
+- Camel DSLs:
+  - Java DSL.
+  - Yaml DSL. Note that the breakpoint must be set on the from/to line, not on the Camel URI line.
+  - XML DSL in Camel Main mode. It implies that it is not working with Camel context specified in Camel XML file.
 - Single context
 - Add and remove breakpoint
 - Inspect some variables when breakpoint is hit

--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-xml-io-dsl</artifactId>
+			<version>${version.camel}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
 			<version>4.1.1</version>

--- a/src/test/java/com/github/cameltooling/dap/internal/BasicDebugForXmlTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/BasicDebugForXmlTest.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ExtendedCamelContext;
+import org.apache.camel.spi.Resource;
+import org.eclipse.lsp4j.debug.SetBreakpointsArguments;
+
+class BasicDebugForXmlTest extends BasicDebugFlowTest {
+	
+	File routeForTest;
+	
+	@Override
+	protected void registerRouteToTest(CamelContext context, String routeId, String logEndpointId) throws Exception {
+		ExtendedCamelContext ecc = context.adapt(ExtendedCamelContext.class);
+		Resource resource = ecc.getResourceLoader().resolveResource("/basic.xml");
+		routeForTest = new File(resource.getURI());
+		ecc.getRoutesLoader().loadRoutes(resource);
+	}
+	
+	@Override
+	protected SetBreakpointsArguments createSetBreakpointArgument() throws FileNotFoundException {
+		return createSetBreakpointArgument(routeForTest, "XXX-breakpoint-XXX");
+	}
+	
+}

--- a/src/test/java/com/github/cameltooling/dap/internal/BasicDebugForXmlWithRoutesTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/BasicDebugForXmlWithRoutesTest.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ExtendedCamelContext;
+import org.apache.camel.spi.Resource;
+import org.eclipse.lsp4j.debug.SetBreakpointsArguments;
+
+class BasicDebugForXmlWithRoutesTest extends BasicDebugFlowTest {
+	
+	File routeForTest;
+	
+	@Override
+	protected void registerRouteToTest(CamelContext context, String routeId, String logEndpointId) throws Exception {
+		ExtendedCamelContext ecc = context.adapt(ExtendedCamelContext.class);
+		ecc.setBacklogTracing(true);
+		Resource resource = ecc.getResourceLoader().resolveResource("/basic-withroutes.xml");
+		routeForTest = new File(resource.getURI());
+		ecc.getRoutesLoader().loadRoutes(resource);
+	}
+	
+	@Override
+	protected SetBreakpointsArguments createSetBreakpointArgument() throws FileNotFoundException {
+		return createSetBreakpointArgument(routeForTest, "XXX-breakpoint-XXX");
+	}
+	
+}

--- a/src/test/resources/basic-withroutes.xml
+++ b/src/test/resources/basic-withroutes.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<routes xmlns="http://camel.apache.org/schema/spring"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring-xml/camel-spring-xml-3.15.0.xsd">
+	<route id="a-route-id">
+		<from uri="direct:testSetBreakpoint" />
+		<setHeader name="header1">
+			<constant>value of header 1</constant>
+		</setHeader>
+		<setHeader name="header2">
+			<constant>value of header 2</constant>
+		</setHeader>
+		<setProperty name="property1">
+			<constant>value of property 1</constant>
+		</setProperty>
+		<setProperty name="property2">
+			<constant>value of property 2</constant>
+		</setProperty>
+		<log message="Log From Test" id="testBasicFlow-log-id" /> <!-- XXX-breakpoint-XXX -->
+	</route>
+</routes>

--- a/src/test/resources/basic.xml
+++ b/src/test/resources/basic.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<route id="a-route-id" xmlns="http://camel.apache.org/schema/spring" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring-xml/camel-spring-xml-3.15.0.xsd">
+    <from uri="direct:testSetBreakpoint" />
+    <setHeader name="header1">
+        <constant>value of header 1</constant>
+    </setHeader>
+    <setHeader name="header2">
+        <constant>value of header 2</constant>
+    </setHeader>
+    <setProperty name="property1">
+        <constant>value of property 1</constant>
+    </setProperty>
+    <setProperty name="property2">
+        <constant>value of property 2</constant>
+    </setProperty>
+    <log message="Log From Test" id="testBasicFlow-log-id" /> <!-- XXX-breakpoint-XXX -->
+</route>


### PR DESCRIPTION
- working with route and routes in Camel Main mode
- not working with camelContext but sounds a problem at Camel level
which doesn't provide the backlogDebugger in this case or at least at
another place or with another configuration. Created another issue for this use case https://issues.redhat.com/browse/FUSETOOLS2-1516

![Screenshot from 2022-02-15 14-39-44](https://user-images.githubusercontent.com/1105127/154074937-8744ade2-d3cc-4aa0-8001-abe95d3e8210.png)
![xmlDebug-vscode](https://user-images.githubusercontent.com/1105127/154076900-e247616c-ab1c-4ecd-bea4-e3be22b4f8c5.png)

