### PR TITLE
FUSETOOLS2-1570 - Allow update of values for "debugger" variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The Camel Debug Server Adapter must use Java Runtime Environment 11+ with `com.s
 - Specific client provided:
   - on [Eclipse Desktop](https://github.com/camel-tooling/camel-dap-client-eclipse), install from [this update site](https://camel-tooling.github.io/camel-dap-client-eclipse/)
   - on [VS Code](https://github.com/camel-tooling/camel-dap-client-vscode), snapshot binary available [here](https://download.jboss.org/jbosstools/vscode/snapshots/vscode-debug-adapter-apache-camel/)
+- Update value of common variables which are grouped in `Debugger` scope
 
 ## How to use it
 

--- a/src/main/java/com/github/cameltooling/dap/internal/model/CamelScope.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/CamelScope.java
@@ -21,6 +21,8 @@ import java.util.Set;
 
 import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
 import org.eclipse.lsp4j.debug.Scope;
+import org.eclipse.lsp4j.debug.SetVariableArguments;
+import org.eclipse.lsp4j.debug.SetVariableResponse;
 import org.eclipse.lsp4j.debug.Variable;
 
 public abstract class CamelScope extends Scope {
@@ -37,7 +39,7 @@ public abstract class CamelScope extends Scope {
 		return breakpointId;
 	}
 	
-	public abstract Set<Variable> createVariables(int variablesReference, ManagedBacklogDebuggerMBean debugger);
+	public abstract Set<? extends Variable> createVariables(int variablesReference, ManagedBacklogDebuggerMBean debugger);
 	
 	protected Variable createVariable(String variableName, String variableValue) {
 		Variable variable = new Variable();
@@ -59,5 +61,7 @@ public abstract class CamelScope extends Scope {
 	public int hashCode() {
 		return Objects.hash(super.hashCode(), breakpointId);
 	}
+
+	public abstract SetVariableResponse setVariableIfInScope(SetVariableArguments args, ManagedBacklogDebuggerMBean backlogDebugger);
 
 }

--- a/src/main/java/com/github/cameltooling/dap/internal/model/CamelStackFrame.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/CamelStackFrame.java
@@ -24,6 +24,12 @@ import org.eclipse.lsp4j.debug.Source;
 import org.eclipse.lsp4j.debug.StackFrame;
 import org.eclipse.lsp4j.debug.Variable;
 
+import com.github.cameltooling.dap.internal.model.scopes.CamelDebuggerScope;
+import com.github.cameltooling.dap.internal.model.scopes.CamelEndpointScope;
+import com.github.cameltooling.dap.internal.model.scopes.CamelExchangeScope;
+import com.github.cameltooling.dap.internal.model.scopes.CamelMessageScope;
+import com.github.cameltooling.dap.internal.model.scopes.CamelProcessorScope;
+
 public class CamelStackFrame extends StackFrame {
 
 	private Set<CamelScope> scopes = new HashSet<>();
@@ -47,10 +53,14 @@ public class CamelStackFrame extends StackFrame {
 
 	public Set<Variable> createVariables(int variablesReference, ManagedBacklogDebuggerMBean debugger) {
 		Set<Variable> variables = new HashSet<>();
-		for (CamelScope camelScope : scopes) {
+		for (CamelScope camelScope : getScopes()) {
 			variables.addAll(camelScope.createVariables(variablesReference, debugger));
 		}
 		return variables;
+	}
+
+	public Set<CamelScope> getScopes() {
+		return scopes;
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelDebuggerScope.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelDebuggerScope.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal.model.scopes;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
+import org.eclipse.lsp4j.debug.SetVariableArguments;
+import org.eclipse.lsp4j.debug.SetVariableResponse;
+
+import com.github.cameltooling.dap.internal.IdUtils;
+import com.github.cameltooling.dap.internal.model.CamelScope;
+import com.github.cameltooling.dap.internal.model.CamelStackFrame;
+import com.github.cameltooling.dap.internal.model.variables.CamelVariable;
+import com.github.cameltooling.dap.internal.model.variables.debugger.BodyIncludeFilesCamelVariable;
+import com.github.cameltooling.dap.internal.model.variables.debugger.BodyIncludeStreamsCamelVariable;
+import com.github.cameltooling.dap.internal.model.variables.debugger.DebugCounterCamelVariable;
+import com.github.cameltooling.dap.internal.model.variables.debugger.FallbackTimeoutCamelVariable;
+import com.github.cameltooling.dap.internal.model.variables.debugger.LoggingLevelCamelVariable;
+import com.github.cameltooling.dap.internal.model.variables.debugger.MaxCharsForBodyCamelVariable;
+
+public class CamelDebuggerScope extends CamelScope {
+
+	public static final String NAME = "Debugger";
+	private Set<CamelVariable> variables = new HashSet<>();
+
+	public CamelDebuggerScope(CamelStackFrame stackframe) {
+		super(NAME, stackframe.getName(), IdUtils.getPositiveIntFromHashCode((stackframe.getId()+"@Debugger@" + stackframe.getName()).hashCode()));
+	}
+	
+	public Set<CamelVariable> createVariables(int variablesReference, ManagedBacklogDebuggerMBean debugger) {
+		if(variablesReference == getVariablesReference()) {
+			variables.clear();
+			variables.add(new LoggingLevelCamelVariable(debugger));
+			variables.add(new MaxCharsForBodyCamelVariable(debugger));
+			variables.add(new DebugCounterCamelVariable(debugger));
+			variables.add(new FallbackTimeoutCamelVariable(debugger));
+			variables.add(new BodyIncludeFilesCamelVariable(debugger));
+			variables.add(new BodyIncludeStreamsCamelVariable(debugger));
+			return variables;
+		}
+		return Collections.emptySet();
+	}
+
+	@Override
+	public SetVariableResponse setVariableIfInScope(SetVariableArguments args, ManagedBacklogDebuggerMBean backlogDebugger) {
+		if (getVariablesReference() == args.getVariablesReference()) {
+			for (CamelVariable variable : variables) {
+				if(args.getName().equals(variable.getName())) {
+					variable.updateValue(backlogDebugger, args.getValue());
+					SetVariableResponse response = new SetVariableResponse();
+					response.setValue(args.getValue());
+					return response;
+				}
+			}
+		}
+		return null;
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelEndpointScope.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelEndpointScope.java
@@ -14,33 +14,39 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.cameltooling.dap.internal.model;
+package com.github.cameltooling.dap.internal.model.scopes;
 
 import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
+import org.eclipse.lsp4j.debug.SetVariableArguments;
+import org.eclipse.lsp4j.debug.SetVariableResponse;
 import org.eclipse.lsp4j.debug.Variable;
 
 import com.github.cameltooling.dap.internal.IdUtils;
+import com.github.cameltooling.dap.internal.model.CamelScope;
+import com.github.cameltooling.dap.internal.model.CamelStackFrame;
 
-public class CamelDebuggerScope extends CamelScope {
-
-	public CamelDebuggerScope(CamelStackFrame stackframe) {
-		super("Debugger", stackframe.getName(), IdUtils.getPositiveIntFromHashCode((stackframe.getId()+"@Debugger@" + stackframe.getName()).hashCode()));
+public class CamelEndpointScope extends CamelScope {
+	
+	public CamelEndpointScope(CamelStackFrame stackframe) {
+		super("Endpoint", stackframe.getName(), IdUtils.getPositiveIntFromHashCode((stackframe.getId()+"@Endpoint@" + stackframe.getName()).hashCode()));
 	}
 	
 	public Set<Variable> createVariables(int variablesReference, ManagedBacklogDebuggerMBean debugger) {
 		Set<Variable> variables = new HashSet<>();
-		if(variablesReference == getVariablesReference()) {
-			variables.add(createVariable("Logging level", debugger.getLoggingLevel()));
-			variables.add(createVariable("Max chars for body", Integer.toString(debugger.getBodyMaxChars())));
-			variables.add(createVariable("Debug counter", Long.toString(debugger.getDebugCounter())));
-			variables.add(createVariable("Fallback timeout", Long.toString(debugger.getFallbackTimeout())));
-			variables.add(createVariable("Body include files", Boolean.toString(debugger.isBodyIncludeFiles())));
-			variables.add(createVariable("Body include streams", Boolean.toString(debugger.isBodyIncludeStreams())));
+		if (variablesReference == getVariablesReference()) {
+			variables.add(createVariable("Name", getName()));
 		}
 		return variables;
 	}
 
+	@Override
+	public SetVariableResponse setVariableIfInScope(SetVariableArguments args, ManagedBacklogDebuggerMBean backlogDebugger) {
+		if (args.getVariablesReference() == getVariablesReference()) {
+			throw new UnsupportedOperationException("The endpoint name cannot be updated.");
+		}
+		return null;
+	}
 }

--- a/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelExchangeScope.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelExchangeScope.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.cameltooling.dap.internal.model;
+package com.github.cameltooling.dap.internal.model.scopes;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -23,9 +23,13 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
+import org.eclipse.lsp4j.debug.SetVariableArguments;
+import org.eclipse.lsp4j.debug.SetVariableResponse;
 import org.eclipse.lsp4j.debug.Variable;
 
 import com.github.cameltooling.dap.internal.IdUtils;
+import com.github.cameltooling.dap.internal.model.CamelScope;
+import com.github.cameltooling.dap.internal.model.CamelStackFrame;
 import com.github.cameltooling.dap.internal.types.EventMessage;
 import com.github.cameltooling.dap.internal.types.ExchangeProperty;
 import com.github.cameltooling.dap.internal.types.UnmarshallerEventMessage;
@@ -65,6 +69,14 @@ public class CamelExchangeScope extends CamelScope {
 			}
 		}
 		return variables;
+	}
+
+	@Override
+	public SetVariableResponse setVariableIfInScope(SetVariableArguments args, ManagedBacklogDebuggerMBean backlogDebugger) {
+		if (getVariablesReference() == args.getVariablesReference()) {
+			throw new UnsupportedOperationException("Not yet supported");
+		}
+		return null;
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelMessageScope.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelMessageScope.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.cameltooling.dap.internal.model;
+package com.github.cameltooling.dap.internal.model.scopes;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -23,9 +23,13 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
+import org.eclipse.lsp4j.debug.SetVariableArguments;
+import org.eclipse.lsp4j.debug.SetVariableResponse;
 import org.eclipse.lsp4j.debug.Variable;
 
 import com.github.cameltooling.dap.internal.IdUtils;
+import com.github.cameltooling.dap.internal.model.CamelScope;
+import com.github.cameltooling.dap.internal.model.CamelStackFrame;
 import com.github.cameltooling.dap.internal.types.EventMessage;
 import com.github.cameltooling.dap.internal.types.Header;
 import com.github.cameltooling.dap.internal.types.UnmarshallerEventMessage;
@@ -65,6 +69,14 @@ public class CamelMessageScope extends CamelScope {
 			}
 		}
 		return variables;
+	}
+	
+	@Override
+	public SetVariableResponse setVariableIfInScope(SetVariableArguments args, ManagedBacklogDebuggerMBean backlogDebugger) {
+		if (getVariablesReference() == args.getVariablesReference()) {
+			throw new UnsupportedOperationException("Not yet supported");
+		}
+		return null;
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelProcessorScope.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelProcessorScope.java
@@ -14,15 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.cameltooling.dap.internal.model;
+package com.github.cameltooling.dap.internal.model.scopes;
 
 import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
+import org.eclipse.lsp4j.debug.SetVariableArguments;
+import org.eclipse.lsp4j.debug.SetVariableResponse;
 import org.eclipse.lsp4j.debug.Variable;
 
 import com.github.cameltooling.dap.internal.IdUtils;
+import com.github.cameltooling.dap.internal.model.CamelScope;
+import com.github.cameltooling.dap.internal.model.CamelStackFrame;
 
 public class CamelProcessorScope extends CamelScope {
 
@@ -40,6 +44,14 @@ public class CamelProcessorScope extends CamelScope {
 			// TODO: variables.add(createVariable("Completed Exchange", debugger.getCompletedExchanges(breakpointId)));
 		}
 		return variables;
+	}
+	
+	@Override
+	public SetVariableResponse setVariableIfInScope(SetVariableArguments args, ManagedBacklogDebuggerMBean backlogDebugger) {
+		if (getVariablesReference() == args.getVariablesReference()) {
+			throw new UnsupportedOperationException("Not yet supported");
+		}
+		return null;
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/dap/internal/model/variables/CamelVariable.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/variables/CamelVariable.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal.model.variables;
+
+import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
+import org.eclipse.lsp4j.debug.Variable;
+
+public abstract class CamelVariable extends Variable {
+
+	public abstract void updateValue(ManagedBacklogDebuggerMBean backlogDebugger, String value);
+
+}

--- a/src/main/java/com/github/cameltooling/dap/internal/model/variables/debugger/BodyIncludeFilesCamelVariable.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/variables/debugger/BodyIncludeFilesCamelVariable.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal.model.variables.debugger;
+
+import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
+
+import com.github.cameltooling.dap.internal.model.variables.CamelVariable;
+
+public class BodyIncludeFilesCamelVariable extends CamelVariable {
+
+	public static final String NAME = "Body include files";
+
+	public BodyIncludeFilesCamelVariable(ManagedBacklogDebuggerMBean debugger) {
+		setName(NAME);
+		setValue(Boolean.toString(debugger.isBodyIncludeFiles()));
+	}
+
+	@Override
+	public void updateValue(ManagedBacklogDebuggerMBean backlogDebugger, String value) {
+		Boolean newValue = Boolean.valueOf(value);
+		backlogDebugger.setBodyIncludeFiles(newValue);
+		setValue(Boolean.toString(newValue));
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/dap/internal/model/variables/debugger/BodyIncludeStreamsCamelVariable.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/variables/debugger/BodyIncludeStreamsCamelVariable.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal.model.variables.debugger;
+
+import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
+
+import com.github.cameltooling.dap.internal.model.variables.CamelVariable;
+
+public class BodyIncludeStreamsCamelVariable extends CamelVariable {
+
+	public static final String NAME = "Body include streams";
+
+	public BodyIncludeStreamsCamelVariable(ManagedBacklogDebuggerMBean debugger) {
+		setName(NAME);
+		setValue(Boolean.toString(debugger.isBodyIncludeStreams()));
+	}
+
+	@Override
+	public void updateValue(ManagedBacklogDebuggerMBean backlogDebugger, String value) {
+		Boolean newValue = Boolean.valueOf(value);
+		backlogDebugger.setBodyIncludeStreams(newValue);
+		setValue(Boolean.toString(newValue));
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/dap/internal/model/variables/debugger/DebugCounterCamelVariable.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/variables/debugger/DebugCounterCamelVariable.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal.model.variables.debugger;
+
+import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
+
+import com.github.cameltooling.dap.internal.model.variables.CamelVariable;
+
+public class DebugCounterCamelVariable extends CamelVariable {
+
+	public static final String NAME = "Debug counter";
+
+	public DebugCounterCamelVariable(ManagedBacklogDebuggerMBean debugger) {
+		setName(NAME);
+		setValue(Long.toString(debugger.getDebugCounter()));
+	}
+
+	@Override
+	public void updateValue(ManagedBacklogDebuggerMBean backlogDebugger, String value) {
+		if("0".equals(value)) {
+			backlogDebugger.resetDebugCounter();
+			setValue(value);
+		} else {
+			throw new IllegalArgumentException("The value of the debug counter can only be reset to 0.");
+		}
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/dap/internal/model/variables/debugger/FallbackTimeoutCamelVariable.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/variables/debugger/FallbackTimeoutCamelVariable.java
@@ -14,27 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.cameltooling.dap.internal.model;
-
-import java.util.HashSet;
-import java.util.Set;
+package com.github.cameltooling.dap.internal.model.variables.debugger;
 
 import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
-import org.eclipse.lsp4j.debug.Variable;
 
-import com.github.cameltooling.dap.internal.IdUtils;
+import com.github.cameltooling.dap.internal.model.variables.CamelVariable;
 
-public class CamelEndpointScope extends CamelScope {
-	
-	public CamelEndpointScope(CamelStackFrame stackframe) {
-		super("Endpoint", stackframe.getName(), IdUtils.getPositiveIntFromHashCode((stackframe.getId()+"@Endpoint@" + stackframe.getName()).hashCode()));
+public class FallbackTimeoutCamelVariable extends CamelVariable {
+
+	public static final String NAME = "Fallback timeout";
+
+	public FallbackTimeoutCamelVariable(ManagedBacklogDebuggerMBean debugger) {
+		setName(NAME);
+		setValue(Long.toString(debugger.getFallbackTimeout()));
 	}
-	
-	public Set<Variable> createVariables(int variablesReference, ManagedBacklogDebuggerMBean debugger) {
-		Set<Variable> variables = new HashSet<>();
-		if (variablesReference == getVariablesReference()) {
-			variables.add(createVariable("Name", getName()));
-		}
-		return variables;
+
+	@Override
+	public void updateValue(ManagedBacklogDebuggerMBean backlogDebugger, String value) {
+		backlogDebugger.setFallbackTimeout(Long.valueOf(value));
+		setValue(value);
 	}
+
 }

--- a/src/main/java/com/github/cameltooling/dap/internal/model/variables/debugger/LoggingLevelCamelVariable.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/variables/debugger/LoggingLevelCamelVariable.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal.model.variables.debugger;
+
+import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
+
+import com.github.cameltooling.dap.internal.model.variables.CamelVariable;
+
+public class LoggingLevelCamelVariable extends CamelVariable {
+	
+	public static final String NAME = "Logging level";
+
+	public LoggingLevelCamelVariable(ManagedBacklogDebuggerMBean debugger) {
+		setName(NAME);
+		setValue(debugger.getLoggingLevel());
+	}
+	
+	@Override
+	public void updateValue(ManagedBacklogDebuggerMBean backlogDebugger, String value) {
+		backlogDebugger.setLoggingLevel(value);
+		setValue(value);
+	}
+	
+}

--- a/src/main/java/com/github/cameltooling/dap/internal/model/variables/debugger/MaxCharsForBodyCamelVariable.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/variables/debugger/MaxCharsForBodyCamelVariable.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal.model.variables.debugger;
+
+import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
+
+import com.github.cameltooling.dap.internal.model.variables.CamelVariable;
+
+public class MaxCharsForBodyCamelVariable extends CamelVariable {
+
+	public static final String NAME = "Max chars for body";
+
+	public MaxCharsForBodyCamelVariable(ManagedBacklogDebuggerMBean debugger) {
+		setName(NAME);
+		setValue(Integer.toString(debugger.getBodyMaxChars()));
+	}
+
+	@Override
+	public void updateValue(ManagedBacklogDebuggerMBean backlogDebugger, String value) {
+		backlogDebugger.setBodyMaxChars(Integer.valueOf(value));
+		setValue(value);
+	}
+
+}

--- a/src/test/java/com/github/cameltooling/dap/internal/BasicDebugFlowTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/BasicDebugFlowTest.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.api.management.mbean.ManagedBacklogDebuggerMBean;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.engine.DefaultProducerTemplate;
 import org.eclipse.lsp4j.debug.Breakpoint;
@@ -36,6 +37,13 @@ import org.eclipse.lsp4j.debug.StoppedEventArguments;
 import org.eclipse.lsp4j.debug.StoppedEventArgumentsReason;
 import org.eclipse.lsp4j.debug.Variable;
 import org.junit.jupiter.api.Test;
+
+import com.github.cameltooling.dap.internal.model.variables.debugger.BodyIncludeFilesCamelVariable;
+import com.github.cameltooling.dap.internal.model.variables.debugger.BodyIncludeStreamsCamelVariable;
+import com.github.cameltooling.dap.internal.model.variables.debugger.DebugCounterCamelVariable;
+import com.github.cameltooling.dap.internal.model.variables.debugger.FallbackTimeoutCamelVariable;
+import com.github.cameltooling.dap.internal.model.variables.debugger.LoggingLevelCamelVariable;
+import com.github.cameltooling.dap.internal.model.variables.debugger.MaxCharsForBodyCamelVariable;
 
 abstract class BasicDebugFlowTest extends BaseTest {
 
@@ -91,16 +99,17 @@ abstract class BasicDebugFlowTest extends BaseTest {
 			 .until(() -> {
 				 return stackAndData.getVariables().size() == 23;
 			 });
+			ManagedBacklogDebuggerMBean debugger = server.getConnectionManager().getBacklogDebugger();
 			List<Variable> variables = stackAndData.getVariables();
 			assertThat(variables)
 				.contains(
 						createVariable("Body", body),
-						createVariable("Logging level","INFO"),
-						createVariable("Max chars for body", "131072"),
-						createVariable("Fallback timeout", "300"),
-						createVariable("Debug counter", "1"),
-						createVariable("Body include files", "true"),
-						createVariable("Body include streams", "false"),
+						new LoggingLevelCamelVariable(debugger),
+						new MaxCharsForBodyCamelVariable(debugger),
+						new FallbackTimeoutCamelVariable(debugger),
+						new DebugCounterCamelVariable(debugger),
+						new BodyIncludeFilesCamelVariable(debugger),
+						new BodyIncludeStreamsCamelVariable(debugger),
 						createVariable("To node", logEndpointId),
 						createVariable("Route ID", routeId),
 						createVariable("header1", "value of header 1"),


### PR DESCRIPTION
Concentrated on this subset first.

To notice are the materialization of specific XXXCamelVariable in the
debug model which are responsible to the update of their values.

In next iterations, other "scopes" will be handled.

![updateDebuggerValue](https://user-images.githubusercontent.com/1105127/159302518-dde40e68-f38c-4acf-946c-8eac829fc7e3.gif)

Nota: not found a nice way to report errors for unsupported one and if the value is invalid. Will keep it for another iteration. In VS Code, there is simply a "Internal error" little message displayed when the value cannot be updated. https://issues.redhat.com/browse/FUSETOOLS2-1574

