### PR TITLE
FUSETOOLS2-1576 - avoid flaky test

### DIFF
--- a/src/test/java/com/github/cameltooling/dap/internal/UpdateDebuggerVariableValueTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/UpdateDebuggerVariableValueTest.java
@@ -223,6 +223,7 @@ class UpdateDebuggerVariableValueTest extends BaseTest {
 		server.next(nextArgs);
 		
 		waitBreakpointNotification(2);
+		awaitAllVariablesFilled(1, DEFAULT_VARIABLES_NUMBER + NUMBER_OF_HEADER);
 		
 		String messagesAsXml = server.getConnectionManager().getBacklogDebugger().dumpTracedMessagesAsXml(SECOND_LOG_ID, false);
 		EventMessage eventMessage = new UnmarshallerEventMessage().getUnmarshalledEventMessage(messagesAsXml);


### PR DESCRIPTION
by waiting that the client used for test has finished its actions before
moving to next step and potentially stopping the Camel Context

Signed-off-by: Aurélien Pupier <apupier@redhat.com>