### PR TITLE
FUSETOOLS2-1599 - support already set breakpoint

### DIFF
--- a/src/main/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServer.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServer.java
@@ -83,7 +83,6 @@ public class CamelDebugAdapterServer implements IDebugProtocolServer {
 	
 	@Override
 	public CompletableFuture<Capabilities> initialize(InitializeRequestArguments args) {
-		client.initialized();
 		Capabilities capabilities = new Capabilities();
 		capabilities.setSupportsSetVariable(Boolean.TRUE);
 		return CompletableFuture.completedFuture(capabilities);
@@ -92,6 +91,9 @@ public class CamelDebugAdapterServer implements IDebugProtocolServer {
 	@Override
 	public CompletableFuture<Void> attach(Map<String, Object> args) {
 		boolean attached = connectionManager.attach(args, client);
+		if (attached) {
+			client.initialized();
+		}
 		OutputEventArguments telemetryEvent = new OutputEventArguments();
 		telemetryEvent.setCategory(OutputEventArgumentsCategory.TELEMETRY);
 		telemetryEvent.setOutput("camel.dap.attach");

--- a/src/test/java/com/github/cameltooling/dap/internal/BaseTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/BaseTest.java
@@ -89,7 +89,13 @@ public abstract class BaseTest {
 	}
 
 	protected void attach(CamelDebugAdapterServer server, Map<String, Object> paramMap) {
+		assertThat(clientProxy.hasReceivedInitializedEvent())
+			.as("The initialized event should not have been sent yet. The debugger has been attached and thus cannot handle the setBreakpoint requests.")
+			.isFalse();
 		server.attach(paramMap);
+		assertThat(clientProxy.hasReceivedInitializedEvent())
+			.as("The initialized event should have been sent right after the attach method is successful. The debugger is ready to receive the setBreakpoint requests.")
+			.isTrue();
 		BacklogDebuggerConnectionManager connectionManager = server.getConnectionManager();
 		assertThat(connectionManager.getMbeanConnection()).as("The MBeanConnection has not been established.").isNotNull();
 		assertThat(connectionManager.getBacklogDebugger()).as("The BacklogDebugger has not been found.").isNotNull();

--- a/src/test/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServerTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServerTest.java
@@ -34,7 +34,7 @@ class CamelDebugAdapterServerTest extends BaseTest {
 	void testInitialize() throws InterruptedException, ExecutionException {
 		CompletableFuture<Capabilities> initialization = initDebugger();
 		assertThat(initialization.get()).isNotNull();
-		assertThat(clientProxy.hasReceivedInitializedEvent()).isTrue();
+		assertThat(clientProxy.hasReceivedInitializedEvent()).isFalse();
 	}
 	
 	@Test


### PR DESCRIPTION
Now, when a breakpoint is set before starting the debugger, the
breakpoint is correctly used. The initializedEvent was sent at the wrong
time before, the debugger was not ready to accept the setBreakpoint
requests as the JMX connection was not ready.

![breakpoinkCanBeSetBeforeStartingTheDebugger](https://user-images.githubusercontent.com/1105127/168257155-81116a36-521c-4321-b535-197dcc59ac30.gif)
