### PR TITLE
Ref #106 - Automatically attach the debugger once ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 /target/
+
+# IntelliJ
+*.iml
+*.ipr
+*.iws
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -46,9 +46,10 @@
 		<sonar.organization>camel-tooling</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
-		<version.camel>3.17.0</version.camel>
+		<version.camel>3.18.0-SNAPSHOT</version.camel>
 		<!-- must be aligned with the one from Camel -->
 		<version.jaxb>2.3.3</version.jaxb>
+		<version.junit.pioneer>1.7.1</version.junit.pioneer>
 	</properties>
 
 	<build>
@@ -222,6 +223,12 @@
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
 			<version>4.2.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit-pioneer</groupId>
+			<artifactId>junit-pioneer</artifactId>
+			<version>${version.junit.pioneer}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,30 @@
 		<version.jaxb>2.3.3</version.jaxb>
 		<version.junit.pioneer>1.7.1</version.junit.pioneer>
 	</properties>
-
+	<repositories>
+		<repository>
+			<id>central</id>
+			<url>https://repo1.maven.org/maven2/</url>
+			<name>Maven Central</name>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+		</repository>
+		<repository>
+			<id>apache.snapshots</id>
+			<url>https://repository.apache.org/snapshots/</url>
+			<name>Apache Snapshot Repo</name>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
+	</repositories>
 	<build>
 		<plugins>
 			<plugin>

--- a/src/main/java/com/github/cameltooling/dap/internal/BacklogDebuggerConnectionManager.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/BacklogDebuggerConnectionManager.java
@@ -264,6 +264,11 @@ public class BacklogDebuggerConnectionManager {
 
 	public void terminate() {
 		if (backlogDebugger != null) {
+			try {
+				backlogDebugger.detach();
+			} catch (Exception e) {
+				LOGGER.warn("Could not detach the debugger: {}", e.getMessage());
+			}
 			backlogDebugger = null;
 		}
 		if (jmxConnector != null) {

--- a/src/test/java/com/github/cameltooling/dap/internal/BaseTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/BaseTest.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import java.util.Scanner;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.camel.CamelContext;
+import org.apache.camel.impl.engine.DefaultProducerTemplate;
 import org.eclipse.lsp4j.debug.Capabilities;
 import org.eclipse.lsp4j.debug.InitializeRequestArguments;
 import org.eclipse.lsp4j.debug.SetBreakpointsArguments;
@@ -44,13 +46,15 @@ public abstract class BaseTest {
 	protected static final int DEFAULT_VARIABLES_NUMBER = 19;
 	protected CamelDebugAdapterServer server;
 	protected DummyCamelDebugClient clientProxy;
+	protected CamelContext context;
+	protected DefaultProducerTemplate producerTemplate;
 
 	public BaseTest() {
 		super();
 	}
 
 	@AfterEach
-	void tearDown() {
+	void tearDown() throws Exception {
 		if (server != null) {
 			server.terminate(new TerminateArguments());
 			server = null;
@@ -58,6 +62,14 @@ public abstract class BaseTest {
 		if (clientProxy != null) {
 			clientProxy.terminated(new TerminatedEventArguments());
 			clientProxy = null;
+		}
+		if (producerTemplate != null) {
+			producerTemplate.close();
+			producerTemplate = null;
+		}
+		if (context != null) {
+			context.close();
+			context = null;
 		}
 	}
 

--- a/src/test/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServerTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServerTest.java
@@ -39,38 +39,34 @@ class CamelDebugAdapterServerTest extends BaseTest {
 	
 	@Test
 	void testAttachToCamelWithPid() throws Exception {
-		try (CamelContext context = new DefaultCamelContext()) {
-			startBasicRoute(context);
-			attachWithPid(server);
-			checkConnectionEstablished();
-		}
+		context = new DefaultCamelContext();
+		startBasicRoute(context);
+		attachWithPid(server);
+		checkConnectionEstablished();
 	}
 
 	@Test
 	void testAttachToCamelWithDefaultJMX() throws Exception {
-		try (CamelContext context = new DefaultCamelContext()) {
-			startBasicRoute(context);
-			attach(server);
-			checkConnectionEstablished();
-		}
+		context = new DefaultCamelContext();
+		startBasicRoute(context);
+		attach(server);
+		checkConnectionEstablished();
 	}
 	
 	@Test
 	void testAttachToCamelWithProvidedJMXURL() throws Exception {
-		try (CamelContext context = new DefaultCamelContext()) {
-			startBasicRoute(context);
-			attachWithJMXURL(server, BacklogDebuggerConnectionManager.DEFAULT_JMX_URI);
-			checkConnectionEstablished();
-		}
+		context = new DefaultCamelContext();
+		startBasicRoute(context);
+		attachWithJMXURL(server, BacklogDebuggerConnectionManager.DEFAULT_JMX_URI);
+		checkConnectionEstablished();
 	}
 	
 	@Test
 	void testFailToAttach() throws Exception {
-		try (CamelContext context = new DefaultCamelContext()) {
-			startBasicRoute(context);
-			server.attach(Collections.singletonMap(BacklogDebuggerConnectionManager.ATTACH_PARAM_JMX_URL, "invalidUrl"));
-			assertThat(clientProxy.getOutputEventArguments().get(0).getOutput()).contains("Please check that the Camel application under debug has the following requirements:");
-		}
+		context = new DefaultCamelContext();
+		startBasicRoute(context);
+		server.attach(Collections.singletonMap(BacklogDebuggerConnectionManager.ATTACH_PARAM_JMX_URL, "invalidUrl"));
+		assertThat(clientProxy.getOutputEventArguments().get(0).getOutput()).contains("Please check that the Camel application under debug has the following requirements:");
 	}
 	
 	private void checkConnectionEstablished() {

--- a/src/test/java/com/github/cameltooling/dap/internal/MultipleThreadsTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/MultipleThreadsTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.engine.DefaultProducerTemplate;
@@ -35,56 +34,53 @@ class MultipleThreadsTest extends BaseTest {
 
 	@Test
 	void test2SuspendedBreakpointsCreates2Threads() throws Exception {
-		try (CamelContext context = new DefaultCamelContext()) {
-			String startEndpointUri1 = "direct:testThreads1";
-			String startEndpointUri2 = "direct:testThreads2";
-			context.addRoutes(new RouteBuilder() {
-			
-				@Override
-				public void configure() throws Exception {
-					from(startEndpointUri1)
-						.log("Log from test 1");  // XXX-breakpoint1-XXX
-					
-					from(startEndpointUri2)
-						.log("Log from test 2");  // XXX-breakpoint2-XXX
-				}
-			});
-			context.start();
-			assertThat(context.isStarted()).isTrue();
-			initDebugger();
-			attach(server);
-			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint1-XXX", "XXX-breakpoint2-XXX");
-			
-			server.setBreakpoints(setBreakpointsArguments).get();
-			
-			DefaultProducerTemplate producerTemplate = DefaultProducerTemplate.newInstance(context, startEndpointUri1);
-			producerTemplate.start();
-			
-			CompletableFuture<Object> asyncSendBody1 = producerTemplate.asyncSendBody(startEndpointUri1, "a body 1");
-			CompletableFuture<Object> asyncSendBody2 = producerTemplate.asyncSendBody(startEndpointUri2, "a body 2");
-			
-			waitBreakpointNotification(2);
-			awaitAllVariablesFilled(0);
-			awaitAllVariablesFilled(1, 2*DEFAULT_VARIABLES_NUMBER);
-			StoppedEventArguments stoppedEventArgument1 = clientProxy.getStoppedEventArguments().get(0);
-			assertThat(stoppedEventArgument1.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
-			assertThat(clientProxy.getThreadEventArgumentss()).hasSize(2);
-			assertThat(clientProxy.getThreadEventArgumentss().stream().filter(args -> ThreadEventArgumentsReason.STARTED.equals(args.getReason()))).hasSize(2);
-			
-			assertThat(asyncSendBody1.isDone()).isFalse();
-			assertThat(asyncSendBody2.isDone()).isFalse();	
-			
-			assertThat(clientProxy.getAllStacksAndVars()).hasSize(2);
-			assertThat(clientProxy.getAllStacksAndVars().get(0).getStackFrames()).hasSize(1);
-			server.continue_(new ContinueArguments());
-			
-			waitRouteIsDone(asyncSendBody1);
-			waitRouteIsDone(asyncSendBody2);
-			assertThat(clientProxy.getThreadEventArgumentss()).hasSize(4);
-			assertThat(clientProxy.getThreadEventArgumentss().stream().filter(args -> ThreadEventArgumentsReason.EXITED.equals(args.getReason()))).hasSize(2);
-			
-			producerTemplate.stop();
-		}
+		context = new DefaultCamelContext();
+		String startEndpointUri1 = "direct:testThreads1";
+		String startEndpointUri2 = "direct:testThreads2";
+		context.addRoutes(new RouteBuilder() {
+
+			@Override
+			public void configure() throws Exception {
+				from(startEndpointUri1)
+					.log("Log from test 1");  // XXX-breakpoint1-XXX
+
+				from(startEndpointUri2)
+					.log("Log from test 2");  // XXX-breakpoint2-XXX
+			}
+		});
+		context.start();
+		assertThat(context.isStarted()).isTrue();
+		initDebugger();
+		attach(server);
+		SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint1-XXX", "XXX-breakpoint2-XXX");
+
+		server.setBreakpoints(setBreakpointsArguments).get();
+
+		producerTemplate = DefaultProducerTemplate.newInstance(context, startEndpointUri1);
+		producerTemplate.start();
+
+		CompletableFuture<Object> asyncSendBody1 = producerTemplate.asyncSendBody(startEndpointUri1, "a body 1");
+		CompletableFuture<Object> asyncSendBody2 = producerTemplate.asyncSendBody(startEndpointUri2, "a body 2");
+
+		waitBreakpointNotification(2);
+		awaitAllVariablesFilled(0);
+		awaitAllVariablesFilled(1, 2*DEFAULT_VARIABLES_NUMBER);
+		StoppedEventArguments stoppedEventArgument1 = clientProxy.getStoppedEventArguments().get(0);
+		assertThat(stoppedEventArgument1.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
+		assertThat(clientProxy.getThreadEventArgumentss()).hasSize(2);
+		assertThat(clientProxy.getThreadEventArgumentss().stream().filter(args -> ThreadEventArgumentsReason.STARTED.equals(args.getReason()))).hasSize(2);
+
+		assertThat(asyncSendBody1.isDone()).isFalse();
+		assertThat(asyncSendBody2.isDone()).isFalse();
+
+		assertThat(clientProxy.getAllStacksAndVars()).hasSize(2);
+		assertThat(clientProxy.getAllStacksAndVars().get(0).getStackFrames()).hasSize(1);
+		server.continue_(new ContinueArguments());
+
+		waitRouteIsDone(asyncSendBody1);
+		waitRouteIsDone(asyncSendBody2);
+		assertThat(clientProxy.getThreadEventArgumentss()).hasSize(4);
+		assertThat(clientProxy.getThreadEventArgumentss().stream().filter(args -> ThreadEventArgumentsReason.EXITED.equals(args.getReason()))).hasSize(2);
 	}
 	
 }

--- a/src/test/java/com/github/cameltooling/dap/internal/RemoveBreakpointTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/RemoveBreakpointTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.engine.DefaultProducerTemplate;
@@ -34,35 +33,32 @@ class RemoveBreakpointTest extends BaseTest {
 
 	@Test
 	void testRemoveOneBreakpoint() throws Exception {
-		try (CamelContext context = new DefaultCamelContext()) {
-			String fromUri = "direct:testRemoveBreakpoint";
-			context.addRoutes(new RouteBuilder() {
-			
-				@Override
-				public void configure() throws Exception {
-					from(fromUri)
-						.log("Log from test"); // XXX-breakpoint-XXX
-				}
-			});
-			context.start();
-			assertThat(context.isStarted()).isTrue();
-			initDebugger();
-			attach(server);
-			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint-XXX");
-			server.setBreakpoints(setBreakpointsArguments).get();
-			
-			DefaultProducerTemplate producerTemplate = DefaultProducerTemplate.newInstance(context, fromUri);
-			producerTemplate.start();
-			startRouteAndCheckBreakPointHit(fromUri, producerTemplate);
-			
-			SetBreakpointsArguments unsetBreakpointsArguments = createSetBreakpointArgument();
-			server.setBreakpoints(unsetBreakpointsArguments).get();
-			
-			CompletableFuture<Object> asyncSendBody2 = producerTemplate.asyncSendBody(fromUri, null);
-			waitRouteIsDone(asyncSendBody2);
-			
-			producerTemplate.stop();
-		}
+		context = new DefaultCamelContext();
+		String fromUri = "direct:testRemoveBreakpoint";
+		context.addRoutes(new RouteBuilder() {
+
+			@Override
+			public void configure() throws Exception {
+				from(fromUri)
+					.log("Log from test"); // XXX-breakpoint-XXX
+			}
+		});
+		context.start();
+		assertThat(context.isStarted()).isTrue();
+		initDebugger();
+		attach(server);
+		SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint-XXX");
+		server.setBreakpoints(setBreakpointsArguments).get();
+
+		producerTemplate = DefaultProducerTemplate.newInstance(context, fromUri);
+		producerTemplate.start();
+		startRouteAndCheckBreakPointHit(fromUri, producerTemplate);
+
+		SetBreakpointsArguments unsetBreakpointsArguments = createSetBreakpointArgument();
+		server.setBreakpoints(unsetBreakpointsArguments).get();
+
+		CompletableFuture<Object> asyncSendBody2 = producerTemplate.asyncSendBody(fromUri, null);
+		waitRouteIsDone(asyncSendBody2);
 	}
 
 	private void startRouteAndCheckBreakPointHit(String fromUri, DefaultProducerTemplate producerTemplate) {

--- a/src/test/java/com/github/cameltooling/dap/internal/ResumeAllTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/ResumeAllTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.engine.DefaultProducerTemplate;
@@ -36,58 +35,55 @@ class ResumeAllTest extends BaseTest {
 
 	@Test
 	void testResumeAndSecondBreakpointHitOfAnotherRouteInstance() throws Exception {
-		try (CamelContext context = new DefaultCamelContext()) {
-			String routeId = "a-route-id";
-			String startEndpointUri = "direct:testResume";
-			context.addRoutes(new RouteBuilder() {
-			
-				@Override
-				public void configure() throws Exception {
-					from(startEndpointUri)
-						.routeId(routeId)
-						.log("Log from test");  // XXX-breakpoint-another-route-instance-XXX
-				}
-			});
-			context.start();
-			assertThat(context.isStarted()).isTrue();
-			initDebugger();
-			attach(server);
-			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint-another-route-instance-XXX");
-			
-			server.setBreakpoints(setBreakpointsArguments).get();
-			
-			DefaultProducerTemplate producerTemplate = DefaultProducerTemplate.newInstance(context, startEndpointUri);
-			producerTemplate.start();
-			
-			CompletableFuture<Object> asyncSendBody = producerTemplate.asyncSendBody(startEndpointUri, "a body");
-			
-			waitBreakpointNotification(1);
-			int index = 0;
-			StoppedEventArguments stoppedEventArgument = clientProxy.getStoppedEventArguments().get(index);
-			assertThat(stoppedEventArgument.getThreadId()).isEqualTo(1);
-			assertThat(stoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
-			awaitAllVariablesFilled(0);
-			Variable bodyVariable1 = findBodyVariableAtIndex(index).get();
-			assertThat(bodyVariable1.getValue()).isEqualTo("a body");
-			
-			assertThat(asyncSendBody.isDone()).isFalse();
-			
-			server.continue_(new ContinueArguments());
-			
-			waitRouteIsDone(asyncSendBody);
-			
-			CompletableFuture<Object> asyncSendBody2 = producerTemplate.asyncSendBody(startEndpointUri, "a body 2");
-			
-			assertThat(asyncSendBody2.isDone()).isFalse();
-			
-			waitBreakpointNotification(2);
-			
-			awaitAllVariablesFilled(1);
-			Variable bodyVariable2 = findBodyVariableAtIndex(1).get();
-			assertThat(bodyVariable2.getValue()).isEqualTo("a body 2");
-			
-			producerTemplate.stop();
-		}
+		context = new DefaultCamelContext();
+		String routeId = "a-route-id";
+		String startEndpointUri = "direct:testResume";
+		context.addRoutes(new RouteBuilder() {
+
+			@Override
+			public void configure() throws Exception {
+				from(startEndpointUri)
+					.routeId(routeId)
+					.log("Log from test");  // XXX-breakpoint-another-route-instance-XXX
+			}
+		});
+		context.start();
+		assertThat(context.isStarted()).isTrue();
+		initDebugger();
+		attach(server);
+		SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint-another-route-instance-XXX");
+
+		server.setBreakpoints(setBreakpointsArguments).get();
+
+		producerTemplate = DefaultProducerTemplate.newInstance(context, startEndpointUri);
+		producerTemplate.start();
+
+		CompletableFuture<Object> asyncSendBody = producerTemplate.asyncSendBody(startEndpointUri, "a body");
+
+		waitBreakpointNotification(1);
+		int index = 0;
+		StoppedEventArguments stoppedEventArgument = clientProxy.getStoppedEventArguments().get(index);
+		assertThat(stoppedEventArgument.getThreadId()).isEqualTo(1);
+		assertThat(stoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
+		awaitAllVariablesFilled(0);
+		Variable bodyVariable1 = findBodyVariableAtIndex(index).get();
+		assertThat(bodyVariable1.getValue()).isEqualTo("a body");
+
+		assertThat(asyncSendBody.isDone()).isFalse();
+
+		server.continue_(new ContinueArguments());
+
+		waitRouteIsDone(asyncSendBody);
+
+		CompletableFuture<Object> asyncSendBody2 = producerTemplate.asyncSendBody(startEndpointUri, "a body 2");
+
+		assertThat(asyncSendBody2.isDone()).isFalse();
+
+		waitBreakpointNotification(2);
+
+		awaitAllVariablesFilled(1);
+		Variable bodyVariable2 = findBodyVariableAtIndex(1).get();
+		assertThat(bodyVariable2.getValue()).isEqualTo("a body 2");
 	}
 
 	private Optional<Variable> findBodyVariableAtIndex(int index) {
@@ -96,52 +92,49 @@ class ResumeAllTest extends BaseTest {
 	
 	@Test
 	void testResumeAndSecondBreakpointHitOnSameRouteInstance() throws Exception {
-		try (CamelContext context = new DefaultCamelContext()) {
-			String routeId = "a-route-id";
-			String startEndpointUri = "direct:testResume";
-			context.addRoutes(new RouteBuilder() {
-			
-				@Override
-				public void configure() throws Exception {
-					from(startEndpointUri)
-						.routeId(routeId)
-						.log("Log from test")  // XXX-breakpoint-same-route-instance-XXX
-						.log("second log"); // XXX-breakpoint-same-route-instance-2-XXX
-				}
-			});
-			context.start();
-			assertThat(context.isStarted()).isTrue();
-			initDebugger();
-			attach(server);
-			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint-same-route-instance-XXX", "XXX-breakpoint-same-route-instance-2-XXX");
-			
-			server.setBreakpoints(setBreakpointsArguments).get();
-			
-			DefaultProducerTemplate producerTemplate = DefaultProducerTemplate.newInstance(context, startEndpointUri);
-			producerTemplate.start();
-			
-			CompletableFuture<Object> asyncSendBody = producerTemplate.asyncSendBody(startEndpointUri, "a body");
-			
-			waitBreakpointNotification(1);
-			StoppedEventArguments stoppedEventArgument = clientProxy.getStoppedEventArguments().get(0);
-			assertThat(stoppedEventArgument.getThreadId()).isEqualTo(1);
-			assertThat(stoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
-			assertThat(asyncSendBody.isDone()).isFalse();
-			awaitAllVariablesFilled(0);
-			server.continue_(new ContinueArguments());
-			
-			waitBreakpointNotification(2);
-			StoppedEventArguments secondStoppedEventArgument = clientProxy.getStoppedEventArguments().get(1);
-			assertThat(secondStoppedEventArgument.getThreadId()).isEqualTo(2);
-			assertThat(secondStoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
-			assertThat(asyncSendBody.isDone()).isFalse();
-			awaitAllVariablesFilled(1);
-			server.continue_(new ContinueArguments());
-			
-			waitRouteIsDone(asyncSendBody);
-			
-			producerTemplate.stop();
-		}
+		context = new DefaultCamelContext();
+		String routeId = "a-route-id";
+		String startEndpointUri = "direct:testResume";
+		context.addRoutes(new RouteBuilder() {
+
+			@Override
+			public void configure() throws Exception {
+				from(startEndpointUri)
+					.routeId(routeId)
+					.log("Log from test")  // XXX-breakpoint-same-route-instance-XXX
+					.log("second log"); // XXX-breakpoint-same-route-instance-2-XXX
+			}
+		});
+		context.start();
+		assertThat(context.isStarted()).isTrue();
+		initDebugger();
+		attach(server);
+		SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint-same-route-instance-XXX", "XXX-breakpoint-same-route-instance-2-XXX");
+
+		server.setBreakpoints(setBreakpointsArguments).get();
+
+		producerTemplate = DefaultProducerTemplate.newInstance(context, startEndpointUri);
+		producerTemplate.start();
+
+		CompletableFuture<Object> asyncSendBody = producerTemplate.asyncSendBody(startEndpointUri, "a body");
+
+		waitBreakpointNotification(1);
+		StoppedEventArguments stoppedEventArgument = clientProxy.getStoppedEventArguments().get(0);
+		assertThat(stoppedEventArgument.getThreadId()).isEqualTo(1);
+		assertThat(stoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
+		assertThat(asyncSendBody.isDone()).isFalse();
+		awaitAllVariablesFilled(0);
+		server.continue_(new ContinueArguments());
+
+		waitBreakpointNotification(2);
+		StoppedEventArguments secondStoppedEventArgument = clientProxy.getStoppedEventArguments().get(1);
+		assertThat(secondStoppedEventArgument.getThreadId()).isEqualTo(2);
+		assertThat(secondStoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
+		assertThat(asyncSendBody.isDone()).isFalse();
+		awaitAllVariablesFilled(1);
+		server.continue_(new ContinueArguments());
+
+		waitRouteIsDone(asyncSendBody);
 	}
 	
 }

--- a/src/test/java/com/github/cameltooling/dap/internal/ResumeSingleThreadTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/ResumeSingleThreadTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.engine.DefaultProducerTemplate;
@@ -34,67 +33,64 @@ class ResumeSingleThreadTest extends BaseTest {
 
 	@Test
 	void testResume() throws Exception {
-		try (CamelContext context = new DefaultCamelContext()) {
-			String routeId1 = "a-route-id-1";
-			String startEndpointUri1 = "direct:testResume1";
-			String routeId2 = "a-route-id-2";
-			String startEndpointUri2 = "direct:testResume2";
-			context.addRoutes(new RouteBuilder() {
-			
-				@Override
-				public void configure() throws Exception {
-					from(startEndpointUri1)
-						.routeId(routeId1)
-						.log("Log from test 1");  // XXX-breakpoint1-XXX
-						
-					from(startEndpointUri2)
-						.routeId(routeId2)
-						.log("Log from test 2");  // XXX-breakpoint2-XXX
-				}
-			});
-			context.start();
-			assertThat(context.isStarted()).isTrue();
-			initDebugger();
-			attach(server);
-			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint1-XXX", "XXX-breakpoint2-XXX");
-			
-			server.setBreakpoints(setBreakpointsArguments).get();
-			
-			DefaultProducerTemplate producerTemplate = DefaultProducerTemplate.newInstance(context, startEndpointUri1);
-			producerTemplate.start();
-			
-			CompletableFuture<Object> asyncSendBody1 = producerTemplate.asyncSendBody(startEndpointUri1, "a body1");
-			waitBreakpointNotification(1);
-			awaitAllVariablesFilled(0);
-			CompletableFuture<Object> asyncSendBody2 = producerTemplate.asyncSendBody(startEndpointUri2, "a body2");
-			
-			waitBreakpointNotification(2);
-			awaitAllVariablesFilled(1, DEFAULT_VARIABLES_NUMBER *2);
-			StoppedEventArguments stoppedEventArgument = clientProxy.getStoppedEventArguments().get(0);
-			assertThat(stoppedEventArgument.getThreadId()).isEqualTo(1);
-			assertThat(stoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
-			assertThat(asyncSendBody1.isDone()).isFalse();
-			
-			StoppedEventArguments secondStoppedEventArgument = clientProxy.getStoppedEventArguments().get(1);
-			assertThat(secondStoppedEventArgument.getThreadId()).isEqualTo(2);
-			assertThat(secondStoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
-			assertThat(asyncSendBody2.isDone()).isFalse();
-			
-			
-			ContinueArguments continueArgs1 = new ContinueArguments();
-			continueArgs1.setThreadId(1);
-			server.continue_(continueArgs1);
-			
-			waitRouteIsDone(asyncSendBody1);
-			assertThat(asyncSendBody2.isDone()).isFalse();
-			
-			ContinueArguments continueArgs2 = new ContinueArguments();
-			continueArgs2.setThreadId(2);
-			server.continue_(continueArgs2);
-			waitRouteIsDone(asyncSendBody2);
-			
-			producerTemplate.stop();
-		}
+		context = new DefaultCamelContext();
+		String routeId1 = "a-route-id-1";
+		String startEndpointUri1 = "direct:testResume1";
+		String routeId2 = "a-route-id-2";
+		String startEndpointUri2 = "direct:testResume2";
+		context.addRoutes(new RouteBuilder() {
+
+			@Override
+			public void configure() throws Exception {
+				from(startEndpointUri1)
+					.routeId(routeId1)
+					.log("Log from test 1");  // XXX-breakpoint1-XXX
+
+				from(startEndpointUri2)
+					.routeId(routeId2)
+					.log("Log from test 2");  // XXX-breakpoint2-XXX
+			}
+		});
+		context.start();
+		assertThat(context.isStarted()).isTrue();
+		initDebugger();
+		attach(server);
+		SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint1-XXX", "XXX-breakpoint2-XXX");
+
+		server.setBreakpoints(setBreakpointsArguments).get();
+
+		producerTemplate = DefaultProducerTemplate.newInstance(context, startEndpointUri1);
+		producerTemplate.start();
+
+		CompletableFuture<Object> asyncSendBody1 = producerTemplate.asyncSendBody(startEndpointUri1, "a body1");
+		waitBreakpointNotification(1);
+		awaitAllVariablesFilled(0);
+		CompletableFuture<Object> asyncSendBody2 = producerTemplate.asyncSendBody(startEndpointUri2, "a body2");
+
+		waitBreakpointNotification(2);
+		awaitAllVariablesFilled(1, DEFAULT_VARIABLES_NUMBER *2);
+		StoppedEventArguments stoppedEventArgument = clientProxy.getStoppedEventArguments().get(0);
+		assertThat(stoppedEventArgument.getThreadId()).isEqualTo(1);
+		assertThat(stoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
+		assertThat(asyncSendBody1.isDone()).isFalse();
+
+		StoppedEventArguments secondStoppedEventArgument = clientProxy.getStoppedEventArguments().get(1);
+		assertThat(secondStoppedEventArgument.getThreadId()).isEqualTo(2);
+		assertThat(secondStoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
+		assertThat(asyncSendBody2.isDone()).isFalse();
+
+
+		ContinueArguments continueArgs1 = new ContinueArguments();
+		continueArgs1.setThreadId(1);
+		server.continue_(continueArgs1);
+
+		waitRouteIsDone(asyncSendBody1);
+		assertThat(asyncSendBody2.isDone()).isFalse();
+
+		ContinueArguments continueArgs2 = new ContinueArguments();
+		continueArgs2.setThreadId(2);
+		server.continue_(continueArgs2);
+		waitRouteIsDone(asyncSendBody2);
 	}
 	
 }

--- a/src/test/java/com/github/cameltooling/dap/internal/SuspendTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/SuspendTest.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.impl.debugger.BacklogDebugger;
+import org.apache.camel.impl.engine.DefaultProducerTemplate;
+import org.eclipse.lsp4j.debug.ConfigurationDoneArguments;
+import org.eclipse.lsp4j.debug.SetBreakpointsArguments;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetSystemProperty;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A test ensuring that message processing can be suspended.
+ */
+class SuspendTest extends BaseTest {
+
+	@Test
+	@SetSystemProperty(key = BacklogDebugger.SUSPEND_MODE_SYSTEM_PROP_NAME, value = "true")
+	void testOnSuspendModeEnabled() throws Exception {
+		try (CamelContext context = new DefaultCamelContext()) {
+			String routeId = "a-route-id";
+			String startEndpointUri = "direct:testResume";
+			context.addRoutes(new RouteBuilder() {
+
+				@Override
+				public void configure() throws Exception {
+					from(startEndpointUri)
+						.routeId(routeId)
+						.log("Log from test");  // XXX-breakpoint-route-instance-1
+				}
+			});
+			context.start();
+			assertThat(context.isStarted()).isTrue();
+			DefaultProducerTemplate producerTemplate = DefaultProducerTemplate.newInstance(context, startEndpointUri);
+			producerTemplate.start();
+
+			producerTemplate.asyncSendBody(startEndpointUri, "a body");
+
+			initDebugger();
+			attach(server);
+
+			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint-route-instance-1");
+			server.setBreakpoints(setBreakpointsArguments).get();
+
+			server.configurationDone(new ConfigurationDoneArguments());
+			waitBreakpointNotification(1);
+
+			producerTemplate.stop();
+		}
+	}
+
+	@Test
+	@SetSystemProperty(key = BacklogDebugger.SUSPEND_MODE_SYSTEM_PROP_NAME, value = "false")
+	void testOnSuspendModeDisabled() throws Exception {
+		try (CamelContext context = new DefaultCamelContext()) {
+			String routeId = "a-route-id";
+			String startEndpointUri = "direct:testResume";
+			context.addRoutes(new RouteBuilder() {
+
+				@Override
+				public void configure() throws Exception {
+					from(startEndpointUri)
+						.routeId(routeId)
+						.log("Log from test");  // XXX-breakpoint-route-instance-2
+				}
+			});
+			context.start();
+			assertThat(context.isStarted()).isTrue();
+			initDebugger();
+			attach(server);
+			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint-route-instance-2");
+
+			server.setBreakpoints(setBreakpointsArguments).get();
+
+			DefaultProducerTemplate producerTemplate = DefaultProducerTemplate.newInstance(context, startEndpointUri);
+			producerTemplate.start();
+
+			producerTemplate.asyncSendBody(startEndpointUri, "a body");
+
+			server.configurationDone(new ConfigurationDoneArguments());
+			waitBreakpointNotification(1);
+
+			producerTemplate.stop();
+		}
+	}
+
+}

--- a/src/test/java/com/github/cameltooling/dap/internal/SuspendTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/SuspendTest.java
@@ -16,7 +16,6 @@
  */
 package com.github.cameltooling.dap.internal;
 
-import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.impl.debugger.BacklogDebugger;
@@ -36,71 +35,65 @@ class SuspendTest extends BaseTest {
 	@Test
 	@SetSystemProperty(key = BacklogDebugger.SUSPEND_MODE_SYSTEM_PROP_NAME, value = "true")
 	void testOnSuspendModeEnabled() throws Exception {
-		try (CamelContext context = new DefaultCamelContext()) {
-			String routeId = "a-route-id";
-			String startEndpointUri = "direct:testResume";
-			context.addRoutes(new RouteBuilder() {
+		context = new DefaultCamelContext();
+		String routeId = "a-route-id";
+		String startEndpointUri = "direct:testResume";
+		context.addRoutes(new RouteBuilder() {
 
-				@Override
-				public void configure() throws Exception {
-					from(startEndpointUri)
-						.routeId(routeId)
-						.log("Log from test");  // XXX-breakpoint-route-instance-1
-				}
-			});
-			context.start();
-			assertThat(context.isStarted()).isTrue();
-			DefaultProducerTemplate producerTemplate = DefaultProducerTemplate.newInstance(context, startEndpointUri);
-			producerTemplate.start();
+			@Override
+			public void configure() throws Exception {
+				from(startEndpointUri)
+					.routeId(routeId)
+					.log("Log from test");  // XXX-breakpoint-route-instance-1
+			}
+		});
+		context.start();
+		assertThat(context.isStarted()).isTrue();
+		producerTemplate = DefaultProducerTemplate.newInstance(context, startEndpointUri);
+		producerTemplate.start();
 
-			producerTemplate.asyncSendBody(startEndpointUri, "a body");
+		producerTemplate.asyncSendBody(startEndpointUri, "a body");
 
-			initDebugger();
-			attach(server);
+		initDebugger();
+		attach(server);
 
-			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint-route-instance-1");
-			server.setBreakpoints(setBreakpointsArguments).get();
+		SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint-route-instance-1");
+		server.setBreakpoints(setBreakpointsArguments).get();
 
-			server.configurationDone(new ConfigurationDoneArguments());
-			waitBreakpointNotification(1);
-
-			producerTemplate.stop();
-		}
+		server.configurationDone(new ConfigurationDoneArguments());
+		waitBreakpointNotification(1);
 	}
 
 	@Test
 	@SetSystemProperty(key = BacklogDebugger.SUSPEND_MODE_SYSTEM_PROP_NAME, value = "false")
 	void testOnSuspendModeDisabled() throws Exception {
-		try (CamelContext context = new DefaultCamelContext()) {
-			String routeId = "a-route-id";
-			String startEndpointUri = "direct:testResume";
-			context.addRoutes(new RouteBuilder() {
+		context = new DefaultCamelContext();
+		String routeId = "a-route-id";
+		String startEndpointUri = "direct:testResume";
+		context.addRoutes(new RouteBuilder() {
 
-				@Override
-				public void configure() throws Exception {
-					from(startEndpointUri)
-						.routeId(routeId)
-						.log("Log from test");  // XXX-breakpoint-route-instance-2
-				}
-			});
-			context.start();
-			assertThat(context.isStarted()).isTrue();
-			initDebugger();
-			attach(server);
-			SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint-route-instance-2");
+			@Override
+			public void configure() throws Exception {
+				from(startEndpointUri)
+					.routeId(routeId)
+					.log("Log from test");  // XXX-breakpoint-route-instance-2
+			}
+		});
+		context.start();
+		assertThat(context.isStarted()).isTrue();
+		initDebugger();
+		attach(server);
+		SetBreakpointsArguments setBreakpointsArguments = createSetBreakpointArgument("XXX-breakpoint-route-instance-2");
 
-			server.setBreakpoints(setBreakpointsArguments).get();
+		server.setBreakpoints(setBreakpointsArguments).get();
 
-			DefaultProducerTemplate producerTemplate = DefaultProducerTemplate.newInstance(context, startEndpointUri);
-			producerTemplate.start();
+		producerTemplate = DefaultProducerTemplate.newInstance(context, startEndpointUri);
+		producerTemplate.start();
 
-			producerTemplate.asyncSendBody(startEndpointUri, "a body");
+		producerTemplate.asyncSendBody(startEndpointUri, "a body");
 
-			server.configurationDone(new ConfigurationDoneArguments());
-			waitBreakpointNotification(1);
-
-			producerTemplate.stop();
-		}
+		server.configurationDone(new ConfigurationDoneArguments());
+		waitBreakpointNotification(1);
 	}
 
 }

--- a/src/test/java/com/github/cameltooling/dap/internal/UpdateDebuggerVariableValueTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/UpdateDebuggerVariableValueTest.java
@@ -57,9 +57,7 @@ class UpdateDebuggerVariableValueTest extends BaseTest {
 	protected static final String SECOND_LOG_ID = "second-log-id";
 	private static final int NUMBER_OF_HEADER = 1;
 	private static final int NUMBER_OF_EXCHANGE_PROPERTY = 1;
-	private DefaultCamelContext context;
 	private Scope debuggerScope;
-	private DefaultProducerTemplate producerTemplate;
 	private CompletableFuture<Object> asyncSendBody;
 
 	@BeforeEach
@@ -103,13 +101,8 @@ class UpdateDebuggerVariableValueTest extends BaseTest {
 	
 	@AfterEach
 	void afterEach() {
-		try {
-			server.continue_(new ContinueArguments());
-			waitRouteIsDone(asyncSendBody);
-			producerTemplate.stop();
-		} finally {
-			context.stop();
-		}
+		server.continue_(new ContinueArguments());
+		waitRouteIsDone(asyncSendBody);
 	}
 
 	@Test


### PR DESCRIPTION
fixes #106 

## Motivation

Thanks to https://issues.apache.org/jira/browse/CAMEL-18217, it is now possible to suspend the message processing by setting an environment. This feature can be leveraged to avoid having to explicitly add a `sleep` in the code in order to ensure that all the breakpoints have been added.

## Modifications:

* Add the support of configuration done to be able to automatically attach the debugger once ready
* Upgrade the version of Camel to have access to the changes for https://issues.apache.org/jira/browse/CAMEL-18217
* Add `junit-pioneer` as test dependency to be able to set the system property within the context of a unit test  
* Rewrite the tests to close the context after the server to prevent warnings of type `java.io.IOException: Failed to get a RMI stub: javax.naming.CommunicationException [Root exception is java.rmi.NoSuchObjectException: no such object in table]`
* Add the maven repository allowing to access to snapshots
* Ignore IntelliJ files (not related to the initial issue)

## Result

I could debug following the steps define in the [blog post](https://camel.apache.org/blog/2022/06/HowToUseCamelRouteTextualDebuggerWithUnitTest/) without the need of adding explicitly a `sleep` in the test case.

The configuration is then as next:

```
{
	"version": "2.0.0",
	"tasks": [
		{
			"label": "Start test with camel.debug profile",
			"type": "shell",
			"command": "mvn", // mvn binary of Maven must be available on command-line
			"args": [
				"test",
				"-Pcamel.debug", // This depends on your project. The goal here is to have camel-debug on the classpath.
			],
			"problemMatcher": "$camel.debug.problemMatcher",
			"presentation": {
				"reveal": "always"
			},
			"options": {
				"env": {
					"CAMEL_DEBUGGER_SUSPEND": "true" // Must be set to suspend the message processing
				}
			},
			"isBackground": true // Must be set as background as the Maven commands doesn't return until the Camel application stops.
		}
	]
}
```

**NB:**  With the latest changes in Camel, in case of Unit tests, it is no more needed to override the methods `isUseDebugger` and `useJmx` to return respectively `false` and `true`.