### PR TITLE
Improve the thread-safety of the code

### DIFF
--- a/src/main/java/com/github/cameltooling/dap/internal/model/CamelScope.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/CamelScope.java
@@ -27,7 +27,7 @@ import org.eclipse.lsp4j.debug.Variable;
 
 public abstract class CamelScope extends Scope {
 
-	private String breakpointId;
+	private final String breakpointId;
 
 	protected CamelScope(String name, String breakpointId, int variableRefId) {
 		setName(name);

--- a/src/main/java/com/github/cameltooling/dap/internal/model/CamelStackFrame.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/CamelStackFrame.java
@@ -16,6 +16,7 @@
  */
 package com.github.cameltooling.dap.internal.model;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -32,7 +33,7 @@ import com.github.cameltooling.dap.internal.model.scopes.CamelProcessorScope;
 
 public class CamelStackFrame extends StackFrame {
 
-	private Set<CamelScope> scopes = new HashSet<>();
+	private volatile Set<CamelScope> scopes = Collections.unmodifiableSet(new HashSet<>());
 
 	public CamelStackFrame(int frameId, String breakpointId, Source source, Integer line) {
 		setId(frameId);
@@ -42,13 +43,14 @@ public class CamelStackFrame extends StackFrame {
 	}
 	
 	public Set<CamelScope> createScopes() {
-		scopes.clear();
-		scopes.add(new CamelDebuggerScope(this));
-		scopes.add(new CamelEndpointScope(this));
-		scopes.add(new CamelProcessorScope(this));
-		scopes.add(new CamelExchangeScope(this));
-		scopes.add(new CamelMessageScope(this));
-		return scopes;
+		final Set<CamelScope> allScopes = new HashSet<>();
+		allScopes.add(new CamelDebuggerScope(this));
+		allScopes.add(new CamelEndpointScope(this));
+		allScopes.add(new CamelProcessorScope(this));
+		allScopes.add(new CamelExchangeScope(this));
+		allScopes.add(new CamelMessageScope(this));
+		this.scopes = Collections.unmodifiableSet(allScopes);
+		return allScopes;
 	}
 
 	public Set<Variable> createVariables(int variablesReference, ManagedBacklogDebuggerMBean debugger) {

--- a/src/main/java/com/github/cameltooling/dap/internal/model/CamelThread.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/CamelThread.java
@@ -29,9 +29,9 @@ import com.github.cameltooling.dap.internal.types.EventMessage;
 
 public class CamelThread extends Thread {
 
-	private String breakpointId;
-	private CamelStackFrame stackFrame;
-	private EventMessage eventMessage;
+	private final String breakpointId;
+	private final CamelStackFrame stackFrame;
+	private final EventMessage eventMessage;
 
 	public CamelThread(int threadId, String breakpointId, EventMessage eventMessage, CamelBreakpoint camelBreakpoint) {
 		setId(threadId);

--- a/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelDebuggerScope.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelDebuggerScope.java
@@ -38,7 +38,7 @@ import com.github.cameltooling.dap.internal.model.variables.debugger.MaxCharsFor
 public class CamelDebuggerScope extends CamelScope {
 
 	public static final String NAME = "Debugger";
-	private Set<CamelVariable> variables = new HashSet<>();
+	private volatile Set<CamelVariable> variables = Collections.unmodifiableSet(new HashSet<>());
 
 	public CamelDebuggerScope(CamelStackFrame stackframe) {
 		super(NAME, stackframe.getName(), IdUtils.getPositiveIntFromHashCode((stackframe.getId()+"@Debugger@" + stackframe.getName()).hashCode()));
@@ -46,14 +46,15 @@ public class CamelDebuggerScope extends CamelScope {
 	
 	public Set<CamelVariable> createVariables(int variablesReference, ManagedBacklogDebuggerMBean debugger) {
 		if(variablesReference == getVariablesReference()) {
-			variables.clear();
-			variables.add(new LoggingLevelCamelVariable(debugger));
-			variables.add(new MaxCharsForBodyCamelVariable(debugger));
-			variables.add(new DebugCounterCamelVariable(debugger));
-			variables.add(new FallbackTimeoutCamelVariable(debugger));
-			variables.add(new BodyIncludeFilesCamelVariable(debugger));
-			variables.add(new BodyIncludeStreamsCamelVariable(debugger));
-			return variables;
+			final Set<CamelVariable> allVariables = new HashSet<>();
+			allVariables.add(new LoggingLevelCamelVariable(debugger));
+			allVariables.add(new MaxCharsForBodyCamelVariable(debugger));
+			allVariables.add(new DebugCounterCamelVariable(debugger));
+			allVariables.add(new FallbackTimeoutCamelVariable(debugger));
+			allVariables.add(new BodyIncludeFilesCamelVariable(debugger));
+			allVariables.add(new BodyIncludeStreamsCamelVariable(debugger));
+			this.variables = Collections.unmodifiableSet(allVariables);
+			return allVariables;
 		}
 		return Collections.emptySet();
 	}

--- a/src/main/java/com/github/cameltooling/dap/internal/model/variables/exchange/ExchangePropertiesVariable.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/variables/exchange/ExchangePropertiesVariable.java
@@ -30,8 +30,8 @@ import com.github.cameltooling.dap.internal.types.ExchangeProperty;
 
 public class ExchangePropertiesVariable extends Variable {
 	
-	private List<ExchangeProperty> exchangeProperties;
-	private String breakpointId;
+	private final List<ExchangeProperty> exchangeProperties;
+	private final String breakpointId;
 
 	public ExchangePropertiesVariable(int parentVariablesReference, List<ExchangeProperty> exchangeProperties, String breakpointId) {
 		this.exchangeProperties = exchangeProperties;

--- a/src/main/java/com/github/cameltooling/dap/internal/model/variables/message/MessageBodyCamelVariable.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/variables/message/MessageBodyCamelVariable.java
@@ -23,7 +23,7 @@ import com.github.cameltooling.dap.internal.model.variables.CamelVariable;
 public class MessageBodyCamelVariable extends CamelVariable {
 
 	public static final String NAME = "Body";
-	private String breakpointId;
+	private final String breakpointId;
 
 	public MessageBodyCamelVariable(String breakpointId, String body) {
 		this.breakpointId = breakpointId;

--- a/src/main/java/com/github/cameltooling/dap/internal/model/variables/message/MessageHeadersVariable.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/variables/message/MessageHeadersVariable.java
@@ -30,8 +30,8 @@ import com.github.cameltooling.dap.internal.types.Header;
 
 public class MessageHeadersVariable extends Variable {
 	
-	private List<Header> headers;
-	private String breakpointId;
+	private final List<Header> headers;
+	private final String breakpointId;
 
 	public MessageHeadersVariable(int parentVariablesReference, List<Header> headers, String breakpointId) {
 		this.headers = headers;


### PR DESCRIPTION
## Motivation

Some parts of the code are not really thread safe which could lead to un-predictable behaviors, race conditions issues, ConcurrentModificationException... 

## Modifications:

Even if the changes of this PR don't make the code fully thread safe as some operations are not atomic but at least it addresses the biggest issues which sounds like a good trade-off for the purpose of this code. Indeed making the code fully thread safe would require to rewrite some parts of the code which is not expected for now. 

* Use `final` keyword on fields that are not modified which prevents visibility issues
* Use thread-safe collections
* Use `volatile` keyword on fields read and written by concurrent threads to prevent visibility and ordering issues
* Use `AtomicInteger` as a thread safe counter
* Use the copy-on-write approach to manage the thread-safety of the scopes and variables