### PR TITLE
Ref #114 - Remove the debugger variable UID

### DIFF
--- a/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelMessageScope.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelMessageScope.java
@@ -50,7 +50,6 @@ public class CamelMessageScope extends CamelScope {
 			EventMessage eventMessage = new UnmarshallerEventMessage().getUnmarshalledEventMessage(xml);
 			if(eventMessage != null) {
 				variables.add(createVariable("Exchange ID", eventMessage.getExchangeId()));
-				variables.add(createVariable("UID", Long.toString(eventMessage.getUid())));
 				messageBody = new MessageBodyCamelVariable(getBreakpointId(), eventMessage.getMessage().getBody());
 				variables.add(messageBody);
 				headersVariable = new MessageHeadersVariable(variablesReference, eventMessage.getMessage().getHeaders(), getBreakpointId());

--- a/src/test/java/com/github/cameltooling/dap/internal/BaseTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/BaseTest.java
@@ -43,7 +43,7 @@ import com.github.cameltooling.dap.internal.telemetry.TelemetryEvent;
 
 public abstract class BaseTest {
 
-	protected static final int DEFAULT_VARIABLES_NUMBER = 19;
+	protected static final int DEFAULT_VARIABLES_NUMBER = 18;
 	protected CamelDebugAdapterServer server;
 	protected DummyCamelDebugClient clientProxy;
 	protected CamelContext context;

--- a/src/test/java/com/github/cameltooling/dap/internal/BasicDebugFlowTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/BasicDebugFlowTest.java
@@ -97,9 +97,7 @@ abstract class BasicDebugFlowTest extends BaseTest {
 		await().untilAsserted(() -> assertThat(stackAndData.getScopes()).hasSize(5));
 		await("handling of stop event response is finished")
 			.atMost(Duration.ofSeconds(60))
-			.until(() -> {
-				return stackAndData.getVariables().size() == 23;
-			});
+			.untilAsserted(() -> assertThat(stackAndData.getVariables()).hasSize(22));
 		ManagedBacklogDebuggerMBean debugger = server.getConnectionManager().getBacklogDebugger();
 		List<Variable> variables = stackAndData.getVariables();
 		assertThat(variables)


### PR DESCRIPTION
fixes #114

## Motivation

The variable `UID` in the `MESSAGE` section proposed by the debugger is misleading for the end-user, as it could be interpreted as the `UID` of the Camel message while it is actually the `UID` of the backlog tracer event message which is something very internal to the Debugger and IMHO should not be exposed to the end-user.

## Modifications:

* Removes the variable `UID` from the collection of variables to expose
* Fixes the unit tests accordingly