### PR TITLE
FUSETOOLS2-1669 - Use async code in Debug Adapter Server codebase

### DIFF
--- a/src/main/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServer.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServer.java
@@ -17,13 +17,13 @@
 package com.github.cameltooling.dap.internal;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
@@ -87,31 +87,41 @@ public class CamelDebugAdapterServer implements IDebugProtocolServer {
 	
 	@Override
 	public CompletableFuture<Capabilities> initialize(InitializeRequestArguments args) {
-		Capabilities capabilities = new Capabilities();
-		capabilities.setSupportsSetVariable(Boolean.TRUE);
-		capabilities.setSupportsConditionalBreakpoints(Boolean.TRUE);
-		capabilities.setSupportsConfigurationDoneRequest(Boolean.TRUE);
-		return CompletableFuture.completedFuture(capabilities);
+		return supplyAsync(
+			() -> {
+				Capabilities capabilities = new Capabilities();
+				capabilities.setSupportsSetVariable(Boolean.TRUE);
+				capabilities.setSupportsConditionalBreakpoints(Boolean.TRUE);
+				capabilities.setSupportsConfigurationDoneRequest(Boolean.TRUE);
+				return capabilities;
+			}
+		);
 	}
 	
 	@Override
 	public CompletableFuture<Void> attach(Map<String, Object> args) {
-		IDebugProtocolClient protocolClient = client;
-		boolean attached = connectionManager.attach(args, protocolClient);
-		if (attached) {
-			protocolClient.initialized();
-		}
-		OutputEventArguments telemetryEvent = new OutputEventArguments();
-		telemetryEvent.setCategory(OutputEventArgumentsCategory.TELEMETRY);
-		telemetryEvent.setOutput("camel.dap.attach");
-		telemetryEvent.setData(new TelemetryEvent("camel.dap.attach", Collections.singletonMap("success", attached)));
-		protocolClient.output(telemetryEvent);
-		return CompletableFuture.completedFuture(null);
+		return runAsync(
+			() -> {
+				IDebugProtocolClient protocolClient = client;
+				boolean attached = connectionManager.attach(args, protocolClient);
+				if (attached) {
+					protocolClient.initialized();
+				}
+				OutputEventArguments telemetryEvent = new OutputEventArguments();
+				telemetryEvent.setCategory(OutputEventArgumentsCategory.TELEMETRY);
+				telemetryEvent.setOutput("camel.dap.attach");
+				telemetryEvent.setData(new TelemetryEvent("camel.dap.attach", Collections.singletonMap("success", attached)));
+				protocolClient.output(telemetryEvent);
+			}
+		);
 	}
 	
 	@Override
 	public CompletableFuture<SetBreakpointsResponse> setBreakpoints(SetBreakpointsArguments setBreakpointsArguments) {
-		SetBreakpointsResponse response = new SetBreakpointsResponse();
+		return supplyAsync(() -> setBreakpointsSync(setBreakpointsArguments));
+	}
+
+	private SetBreakpointsResponse setBreakpointsSync(SetBreakpointsArguments setBreakpointsArguments) {
 		Source source = setBreakpointsArguments.getSource();
 		SourceBreakpoint[] sourceBreakpoints = setBreakpointsArguments.getBreakpoints();
 		Breakpoint[] breakpoints = new Breakpoint[sourceBreakpoints.length];
@@ -154,8 +164,9 @@ public class CamelDebugAdapterServer implements IDebugProtocolServer {
 		}
 		removeOldBreakpoints(source, breakpointIds);
 		sourceToBreakpointIds.put(source.getPath(), breakpointIds);
+		SetBreakpointsResponse response = new SetBreakpointsResponse();
 		response.setBreakpoints(breakpoints);
-		return CompletableFuture.completedFuture(response);
+		return response;
 	}
 
 	private void removeOldBreakpoints(Source source, Set<String> breakpointIds) {
@@ -169,71 +180,89 @@ public class CamelDebugAdapterServer implements IDebugProtocolServer {
 	
 	@Override
 	public CompletableFuture<ThreadsResponse> threads() {
-		ThreadsResponse value = new ThreadsResponse();
-		Set<CamelThread> threads = connectionManager.getCamelThreads();
-		value.setThreads(threads.toArray(new CamelThread[0]));
-		return CompletableFuture.completedFuture(value);
+		return supplyAsync(
+			() -> {
+				Set<CamelThread> threads = connectionManager.getCamelThreads();
+				ThreadsResponse value = new ThreadsResponse();
+				value.setThreads(threads.toArray(new CamelThread[0]));
+				return value;
+			}
+		);
 	}
 	
 	@Override
 	public CompletableFuture<StackTraceResponse> stackTrace(StackTraceArguments args) {
-		StackTraceResponse response = new StackTraceResponse();
-		Set<StackFrame> stackFrames = new HashSet<>();
-		Set<CamelThread> camelThreads = connectionManager.getCamelThreads();
-		Optional<CamelThread> camelThreadOptional = camelThreads.stream().filter(camelThread -> camelThread.getId() == args.getThreadId()).findAny();
-		if (camelThreadOptional.isPresent()) {
-			CamelThread camelThread = camelThreadOptional.get();
-			stackFrames.add(camelThread.getStackFrame());
-		}
-		response.setStackFrames(stackFrames.toArray(new StackFrame[0]) );
-		return CompletableFuture.completedFuture(response);
+		return supplyAsync(
+			() -> {
+				Set<CamelThread> camelThreads = connectionManager.getCamelThreads();
+				Optional<CamelThread> camelThreadOptional = camelThreads.stream().filter(camelThread -> camelThread.getId() == args.getThreadId()).findAny();
+				Set<StackFrame> stackFrames = new HashSet<>();
+				if (camelThreadOptional.isPresent()) {
+					CamelThread camelThread = camelThreadOptional.get();
+					stackFrames.add(camelThread.getStackFrame());
+				}
+				StackTraceResponse response = new StackTraceResponse();
+				response.setStackFrames(stackFrames.toArray(new StackFrame[0]));
+				return response;
+			}
+		);
 	}
 	
 	@Override
 	public CompletableFuture<ScopesResponse> scopes(ScopesArguments args) {
-		ScopesResponse response = new ScopesResponse();
-		Optional<CamelStackFrame> camelStackFrameOptional = connectionManager.getCamelThreads().stream()
-				.map(CamelThread::getStackFrame)
-				.filter(stackFrame -> args.getFrameId() == stackFrame.getId())
-				.findAny();
-		Set<CamelScope> scopes = new HashSet<>();
-		if (camelStackFrameOptional.isPresent()) {
-			scopes = camelStackFrameOptional.get().createScopes();
-		}
-		response.setScopes(scopes.toArray(new Scope[0]));
-		return CompletableFuture.completedFuture(response);
+		return supplyAsync(
+			() -> {
+				Optional<CamelStackFrame> camelStackFrameOptional = connectionManager.getCamelThreads().stream()
+					.map(CamelThread::getStackFrame)
+					.filter(stackFrame -> args.getFrameId() == stackFrame.getId())
+					.findAny();
+				Set<CamelScope> scopes = new HashSet<>();
+				if (camelStackFrameOptional.isPresent()) {
+					scopes = camelStackFrameOptional.get().createScopes();
+				}
+				ScopesResponse response = new ScopesResponse();
+				response.setScopes(scopes.toArray(new Scope[0]));
+				return response;
+			}
+		);
 	}
 
 	@Override
 	public CompletableFuture<VariablesResponse> variables(VariablesArguments args) {
-		int variablesReference = args.getVariablesReference();
-		VariablesResponse response = new VariablesResponse();
-		Set<Variable> variables = new HashSet<>();
-		
-		ManagedBacklogDebuggerMBean debugger = connectionManager.getBacklogDebugger();
-		for (CamelThread camelThread : connectionManager.getCamelThreads()) {
-			variables.addAll(camelThread.createVariables(variablesReference, debugger));
-		}
-		response.setVariables(variables.toArray(new Variable[0]));
-		return CompletableFuture.completedFuture(response);
+		return supplyAsync(
+			() -> {
+				Set<Variable> variables = new HashSet<>();
+				ManagedBacklogDebuggerMBean debugger = connectionManager.getBacklogDebugger();
+				for (CamelThread camelThread : connectionManager.getCamelThreads()) {
+					variables.addAll(camelThread.createVariables(args.getVariablesReference(), debugger));
+				}
+				VariablesResponse response = new VariablesResponse();
+				response.setVariables(variables.toArray(new Variable[0]));
+				return response;
+			}
+		);
 	}
 
 	@Override
 	public CompletableFuture<ContinueResponse> continue_(ContinueArguments args) {
-		ContinueResponse response = new ContinueResponse();
-		int threadId = args.getThreadId();
-		if (threadId != 0) {
-			response.setAllThreadsContinued(Boolean.FALSE);
-			Optional<CamelThread> findAny = findThread(threadId);
-			if (findAny.isPresent()) {
-				CamelThread camelThread = findAny.get();
-				connectionManager.resume(camelThread);
+		return supplyAsync(
+			() -> {
+				ContinueResponse response = new ContinueResponse();
+				int threadId = args.getThreadId();
+				if (threadId != 0) {
+					response.setAllThreadsContinued(Boolean.FALSE);
+					Optional<CamelThread> findAny = findThread(threadId);
+					if (findAny.isPresent()) {
+						CamelThread camelThread = findAny.get();
+						connectionManager.resume(camelThread);
+					}
+				} else {
+					connectionManager.resumeAll();
+					response.setAllThreadsContinued(Boolean.TRUE);
+				}
+				return response;
 			}
-		} else {
-			connectionManager.resumeAll();
-			response.setAllThreadsContinued(Boolean.TRUE);
-		}
-		return CompletableFuture.completedFuture(response);
+		);
 	}
 
 	private Optional<CamelThread> findThread(int threadId) {
@@ -242,46 +271,50 @@ public class CamelDebugAdapterServer implements IDebugProtocolServer {
 	
 	@Override
 	public CompletableFuture<Void> next(NextArguments args) {
-		int threadId = args.getThreadId();
-		Optional<CamelThread> findAny = findThread(threadId);
-		if (findAny.isPresent()) {
-			CamelThread camelThread = findAny.get();
-			connectionManager.next(camelThread);
-		}
-		return CompletableFuture.completedFuture(null);
+		return runAsync(
+			() -> {
+				Optional<CamelThread> findAny = findThread(args.getThreadId());
+				if (findAny.isPresent()) {
+					CamelThread camelThread = findAny.get();
+					connectionManager.next(camelThread);
+				}
+			}
+		);
 	}
 	
 	@Override
 	public CompletableFuture<Void> terminate(TerminateArguments args) {
-		connectionManager.terminate();
-		return CompletableFuture.completedFuture(null);
+		return runAsync(connectionManager::terminate);
 	}
 	
 	@Override
 	public CompletableFuture<Void> disconnect(DisconnectArguments args) {
-		connectionManager.terminate();
-		return CompletableFuture.completedFuture(null);
+		return runAsync(connectionManager::terminate);
 	}
 	
 	@Override
 	public CompletableFuture<SetVariableResponse> setVariable(SetVariableArguments args) {
-		for(CamelThread thread : connectionManager.getCamelThreads()) {
-			for(CamelScope scope : thread.getStackFrame().getScopes()) {
-				try {
-					SetVariableResponse response = scope.setVariableIfInScope(args, connectionManager.getBacklogDebugger());
-					if (response != null) {
-						return CompletableFuture.completedFuture(response);
+		return supplyAsync(
+			() -> {
+				for(CamelThread thread : connectionManager.getCamelThreads()) {
+					for(CamelScope scope : thread.getStackFrame().getScopes()) {
+						try {
+							SetVariableResponse response = scope.setVariableIfInScope(args, connectionManager.getBacklogDebugger());
+							if (response != null) {
+								return response;
+							}
+						} catch (Exception ex) {
+							OutputEventArguments eventToAlertUser = new OutputEventArguments();
+							eventToAlertUser.setCategory(OutputEventArgumentsCategory.STDERR);
+							eventToAlertUser.setOutput("Cannot set variable " + args.getName() + ": "+ ex.getClass().getCanonicalName() + ": " + ex.getMessage());
+							client.output(eventToAlertUser);
+							throw ex;
+						}
 					}
-				} catch (Exception ex) {
-					OutputEventArguments eventToAlertUser = new OutputEventArguments();
-					eventToAlertUser.setCategory(OutputEventArgumentsCategory.STDERR);
-					eventToAlertUser.setOutput("Cannot set variable " + args.getName() + ": "+ ex.getClass().getCanonicalName() + ": " + ex.getMessage());
-					client.output(eventToAlertUser);
-					throw ex;
 				}
+				return null;
 			}
-		}
-		return CompletableFuture.completedFuture(null);
+		);
 	}
 
 	public BacklogDebuggerConnectionManager getConnectionManager() {
@@ -291,12 +324,57 @@ public class CamelDebugAdapterServer implements IDebugProtocolServer {
 	@Override
 	public CompletableFuture<Void> configurationDone(ConfigurationDoneArguments args) {
 		// Resume potentially the message processing
-		return CompletableFuture.runAsync(
+		return runAsync(
 			() -> {
 				try {
 					connectionManager.getBacklogDebugger().attach();
 				} catch (Exception e) {
 					LOGGER.warn("Could not attach the debugger: {}", e.getMessage());
+				}
+			}
+		);
+	}
+
+	/**
+	 * Executes asynchronously the given task ensuring that the context class loader is properly set to ensure that
+	 * the classes from third party libraries are found.
+	 *
+	 * @param runnable the task to execute
+	 * @return the new CompletableFuture
+	 */
+	private static CompletableFuture<Void> runAsync(Runnable runnable) {
+		final ClassLoader callerCCL = Thread.currentThread().getContextClassLoader();
+		return CompletableFuture.runAsync(
+			() -> {
+				final ClassLoader currentCCL = Thread.currentThread().getContextClassLoader();
+				try {
+					Thread.currentThread().setContextClassLoader(callerCCL);
+					runnable.run();
+				} finally {
+					Thread.currentThread().setContextClassLoader(currentCCL);
+				}
+			}
+		);
+	}
+
+	/**
+	 * Calls asynchronously the given supplier ensuring that the context class loader is properly set to ensure that
+	 * the classes from third party libraries are found.
+	 *
+	 * @param supplier the supplier to call
+	 * @return the new CompletableFuture
+	 * @param <U> the type of the result
+	 */
+	private static <U> CompletableFuture<U> supplyAsync(Supplier<U> supplier) {
+		final ClassLoader callerCCL = Thread.currentThread().getContextClassLoader();
+		return CompletableFuture.supplyAsync(
+			() -> {
+				final ClassLoader currentCCL = Thread.currentThread().getContextClassLoader();
+				try {
+					Thread.currentThread().setContextClassLoader(callerCCL);
+					return supplier.get();
+				} finally {
+					Thread.currentThread().setContextClassLoader(currentCCL);
 				}
 			}
 		);

--- a/src/test/java/com/github/cameltooling/dap/internal/BaseTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/BaseTest.java
@@ -56,7 +56,7 @@ public abstract class BaseTest {
 	@AfterEach
 	void tearDown() throws Exception {
 		if (server != null) {
-			server.terminate(new TerminateArguments());
+			server.terminate(new TerminateArguments()).get();
 			server = null;
 		}
 		if (clientProxy != null) {
@@ -81,12 +81,12 @@ public abstract class BaseTest {
 			});
 	}
 
-	protected void attachWithPid(CamelDebugAdapterServer server) {
+	protected void attachWithPid(CamelDebugAdapterServer server) throws Exception {
 		Map<String, Object> paramMap = Collections.singletonMap(BacklogDebuggerConnectionManager.ATTACH_PARAM_PID, Long.toString(ProcessHandle.current().pid()));
 		attach(server, paramMap);
 	}
 	
-	protected void attachWithJMXURL(CamelDebugAdapterServer server, String jmxUrl) {
+	protected void attachWithJMXURL(CamelDebugAdapterServer server, String jmxUrl) throws Exception {
 		Map<String, Object> paramMap = Collections.singletonMap(BacklogDebuggerConnectionManager.ATTACH_PARAM_JMX_URL, jmxUrl);
 		attach(server, paramMap);
 	}
@@ -96,15 +96,15 @@ public abstract class BaseTest {
 	 * 
 	 * @param server
 	 */
-	protected void attach(CamelDebugAdapterServer server) {
+	protected void attach(CamelDebugAdapterServer server) throws Exception {
 		attach(server, Collections.emptyMap());
 	}
 
-	protected void attach(CamelDebugAdapterServer server, Map<String, Object> paramMap) {
+	protected void attach(CamelDebugAdapterServer server, Map<String, Object> paramMap) throws Exception {
 		assertThat(clientProxy.hasReceivedInitializedEvent())
 			.as("The initialized event should not have been sent yet. The debugger has been attached and thus cannot handle the setBreakpoint requests.")
 			.isFalse();
-		server.attach(paramMap);
+		server.attach(paramMap).get();
 		assertThat(clientProxy.hasReceivedInitializedEvent())
 			.as("The initialized event should have been sent right after the attach method is successful. The debugger is ready to receive the setBreakpoint requests.")
 			.isTrue();
@@ -179,11 +179,11 @@ public abstract class BaseTest {
 		return -1;
 	}
 
-	protected CompletableFuture<Capabilities> initDebugger() {
+	protected Capabilities initDebugger() throws Exception {
 		server = new CamelDebugAdapterServer();
 		clientProxy = new DummyCamelDebugClient(server);
 		server.connect(clientProxy);
-		return server.initialize(new InitializeRequestArguments());
+		return server.initialize(new InitializeRequestArguments()).get();
 	}
 
 	protected void awaitAllVariablesFilled(int indexOfAllStacksAndVars, int variablesNumber) {

--- a/src/test/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServerTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServerTest.java
@@ -16,24 +16,20 @@
  */
 package com.github.cameltooling.dap.internal;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Collections;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
-import org.eclipse.lsp4j.debug.Capabilities;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class CamelDebugAdapterServerTest extends BaseTest {
 	
 	@Test
-	void testInitialize() throws InterruptedException, ExecutionException {
-		CompletableFuture<Capabilities> initialization = initDebugger();
-		assertThat(initialization.get()).isNotNull();
+	void testInitialize() throws Exception {
+		assertThat(initDebugger()).isNotNull();
 		assertThat(clientProxy.hasReceivedInitializedEvent()).isFalse();
 	}
 	
@@ -65,7 +61,7 @@ class CamelDebugAdapterServerTest extends BaseTest {
 	void testFailToAttach() throws Exception {
 		context = new DefaultCamelContext();
 		startBasicRoute(context);
-		server.attach(Collections.singletonMap(BacklogDebuggerConnectionManager.ATTACH_PARAM_JMX_URL, "invalidUrl"));
+		server.attach(Collections.singletonMap(BacklogDebuggerConnectionManager.ATTACH_PARAM_JMX_URL, "invalidUrl")).get();
 		assertThat(clientProxy.getOutputEventArguments().get(0).getOutput()).contains("Please check that the Camel application under debug has the following requirements:");
 	}
 	

--- a/src/test/java/com/github/cameltooling/dap/internal/DummyCamelDebugClient.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/DummyCamelDebugClient.java
@@ -40,13 +40,13 @@ import org.eclipse.lsp4j.debug.services.IDebugProtocolClient;
 
 public class DummyCamelDebugClient implements IDebugProtocolClient {
 	
-	private boolean hasReceivedInitializedEvent;
-	private List<StoppedEventArguments> stoppedEventArguments = new ArrayList<>();
-	private List<StackAndVarOnStopEvent> wholeStackAndVars = new ArrayList<>();
-	private List<ThreadEventArguments> threadEventArgumentss = new ArrayList<>();
-	private List<OutputEventArguments> telemetryEvents = new ArrayList<>();
-	private List<OutputEventArguments> outputEventArguments = new ArrayList<>();
-	private CamelDebugAdapterServer server;
+	private volatile boolean hasReceivedInitializedEvent;
+	private final List<StoppedEventArguments> stoppedEventArguments = new ArrayList<>();
+	private final List<StackAndVarOnStopEvent> wholeStackAndVars = new ArrayList<>();
+	private final List<ThreadEventArguments> threadEventArgumentss = new ArrayList<>();
+	private final List<OutputEventArguments> telemetryEvents = new ArrayList<>();
+	private final List<OutputEventArguments> outputEventArguments = new ArrayList<>();
+	private final CamelDebugAdapterServer server;
 
 	public DummyCamelDebugClient(CamelDebugAdapterServer server) {
 		this.server = server;

--- a/src/test/java/com/github/cameltooling/dap/internal/UpdateDebuggerVariableValueTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/UpdateDebuggerVariableValueTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -241,7 +242,11 @@ class UpdateDebuggerVariableValueTest extends BaseTest {
 
 		assertThrows(NumberFormatException.class,
 			() -> {
-				server.setVariable(args);
+				try {
+					server.setVariable(args).get();
+				} catch (ExecutionException e) {
+					throw e.getCause();
+				}
 			}
 		);
 


### PR DESCRIPTION
Fix for https://issues.redhat.com/browse/FUSETOOLS2-1669

## Modifications:

* Converts all code of the methods of `CamelDebugAdapterServer` to `Supplier`s or `Runnable`s to call them asynchronously
* Calls `Supplier`s and `Runnable`s using internal utility methods to ensure that the context classloader used is correct otherwise we potentially end up with `java.lang.ClassNotFoundException`
* Fixes the unit tests expecting the calls to be synchronous
* Fixes the visibility issue in `DummyCamelDebugClient`