### PR TITLE
Remove volatile on non thread-safe types

### DIFF
--- a/src/main/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServer.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServer.java
@@ -76,7 +76,7 @@ public class CamelDebugAdapterServer implements IDebugProtocolServer {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(CamelDebugAdapterServer.class);
 
-	private volatile IDebugProtocolClient client;
+	private IDebugProtocolClient client;
 	private final BacklogDebuggerConnectionManager connectionManager = new BacklogDebuggerConnectionManager();
 
 	private final Map<String, Set<String>> sourceToBreakpointIds = new ConcurrentHashMap<>();

--- a/src/main/java/com/github/cameltooling/dap/internal/model/CamelStackFrame.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/CamelStackFrame.java
@@ -33,7 +33,7 @@ import com.github.cameltooling.dap.internal.model.scopes.CamelProcessorScope;
 
 public class CamelStackFrame extends StackFrame {
 
-	private volatile Set<CamelScope> scopes = Collections.unmodifiableSet(new HashSet<>());
+	private Set<CamelScope> scopes = Collections.unmodifiableSet(new HashSet<>());
 
 	public CamelStackFrame(int frameId, String breakpointId, Source source, Integer line) {
 		setId(frameId);

--- a/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelDebuggerScope.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelDebuggerScope.java
@@ -38,7 +38,7 @@ import com.github.cameltooling.dap.internal.model.variables.debugger.MaxCharsFor
 public class CamelDebuggerScope extends CamelScope {
 
 	public static final String NAME = "Debugger";
-	private volatile Set<CamelVariable> variables = Collections.unmodifiableSet(new HashSet<>());
+	private Set<CamelVariable> variables = Collections.unmodifiableSet(new HashSet<>());
 
 	public CamelDebuggerScope(CamelStackFrame stackframe) {
 		super(NAME, stackframe.getName(), IdUtils.getPositiveIntFromHashCode((stackframe.getId()+"@Debugger@" + stackframe.getName()).hashCode()));


### PR DESCRIPTION
as suggested by SonarCloud
https://sonarcloud.io/project/issues?resolved=false&sinceLeakPeriod=true&types=BUG&id=camel-tooling_camel-debug-adapter

it revealed another potential NPE due to dereferencement which I fixed
to avoid introducing another issue
