### PR TITLE
FUSETOOLS2-1819 - Fix regression when updating value

### DIFF
--- a/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelExchangeScope.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelExchangeScope.java
@@ -65,6 +65,8 @@ public class CamelExchangeScope extends CamelScope {
 	public SetVariableResponse setVariableIfInScope(SetVariableArguments args, ManagedBacklogDebuggerMBean backlogDebugger) {
 		if (getVariablesReference() == args.getVariablesReference()) {
 			throw new UnsupportedOperationException("Not supported");
+		} else if (exchangeVariable == null) {
+			return null;
 		}
 		return exchangeVariable.setVariableIfInScope(args, backlogDebugger);
 	}

--- a/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelMessageScope.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelMessageScope.java
@@ -74,9 +74,10 @@ public class CamelMessageScope extends CamelScope {
 			} else {
 				throw new UnsupportedOperationException("Not supported");
 			}
-		} else {
-			return headersVariable.setVariableIfInScope(args, debugger);
+		} else if (headersVariable == null) {
+			return null;
 		}
+		return headersVariable.setVariableIfInScope(args, debugger);
 	}
 
 	public MessageHeadersVariable getHeadersVariable() {


### PR DESCRIPTION
Unfortunately, I'm unable to reproduce the issue in a test. I guess it is due to the way the route is launched but not found the trick

EDIT: I think it is more probably because the client implementation has changed and that the request to all variables became lazy. In oru tests, the "Dummy client" is still not lazy which explains why I do not reproduce, i will need to improve the "DummyClient" implementation in our test suite