### PR TITLE
Use a GitHub group to assign Dependabot reviewer - fix name using

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,11 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 10
     reviewers:
-      - vs-code-dependabot-reviewers
+      - camel-tooling/vs-code-dependabot-reviewers
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
     reviewers:
-      - vs-code-dependabot-reviewers
+      - camel-tooling/vs-code-dependabot-reviewers


### PR DESCRIPTION
organization prefix

