### PR TITLE
Fix config for deployment of tagged version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,7 +31,7 @@ jobs:
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
     - name: Build, sign and deploy
-      run: mvn -P sign -B deploy
+      run: mvn -P sign,build-extras -B deploy
       env:
         MAVEN_USERNAME: apupier
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}


### PR DESCRIPTION
when specifying a profile in Maven, the `activeByDefault` ones must be provided too to be executed. The build-extras is building source and javadoc. It is required for released version but not for snapshot for deployment to Maven Package Manager.