### PR TITLE
Fix to keep minimal backward compatibility with Camel 4.1-

### DIFF
--- a/src/main/java/com/github/cameltooling/dap/internal/BacklogDebuggerConnectionManager.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/BacklogDebuggerConnectionManager.java
@@ -200,7 +200,8 @@ public class BacklogDebuggerConnectionManager {
 		if (!isStepping && !notifiedSuspendedBreakpointIds.contains(nodeId)) {
 			StoppedEventArguments stoppedEventArgs = new StoppedEventArguments();
 			stoppedEventArgs.setReason(StoppedEventArgumentsReason.BREAKPOINT);
-			String xml = backlogDebugger.dumpTracedMessagesAsXml(nodeId);
+			// Keep using deprecated method to have it still working with 4.1- 
+			String xml = backlogDebugger.dumpTracedMessagesAsXml(nodeId, true);
 			EventMessage eventMessage = new UnmarshallerEventMessage().getUnmarshalledEventMessage(xml);
 			Optional<CamelThread> thread = camelThreads.stream().filter(camelThread -> camelThread.getExchangeId().equals(eventMessage.getExchangeId())).findAny();
 			if(thread.isEmpty()) {

--- a/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelExchangeScope.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelExchangeScope.java
@@ -42,7 +42,8 @@ public class CamelExchangeScope extends CamelScope {
 	public Set<Variable> createVariables(int variablesReference, ManagedBacklogDebuggerMBean debugger) {
 		Set<Variable> variables = new HashSet<>();
 		if (variablesReference == getVariablesReference()) {
-			String xml = debugger.dumpTracedMessagesAsXml(getBreakpointId());
+			// Keep using deprecated method to have it still working with 4.1-
+			String xml = debugger.dumpTracedMessagesAsXml(getBreakpointId(), true);
 			EventMessage eventMessage = new UnmarshallerEventMessage().getUnmarshalledEventMessage(xml);
 			if (eventMessage != null) {
 				variables.add(createVariable("ID", eventMessage.getExchangeId()));

--- a/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelMessageScope.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/scopes/CamelMessageScope.java
@@ -48,7 +48,8 @@ public class CamelMessageScope extends CamelScope {
 	public Set<Variable> createVariables(int variablesReference, ManagedBacklogDebuggerMBean debugger) {
 		Set<Variable> variables = new HashSet<>();
 		if (variablesReference == getVariablesReference()) {
-			String xml = debugger.dumpTracedMessagesAsXml(getBreakpointId());
+			// Keep using deprecated method to have it still working with 4.1-
+			String xml = debugger.dumpTracedMessagesAsXml(getBreakpointId(), true);
 			EventMessage eventMessage = new UnmarshallerEventMessage().getUnmarshalledEventMessage(xml);
 			if(eventMessage != null) {
 				variables.add(createVariable("Exchange ID", eventMessage.getExchangeId()));

--- a/src/test/java/com/github/cameltooling/dap/internal/UpdateDebuggerVariableValueTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/UpdateDebuggerVariableValueTest.java
@@ -262,7 +262,8 @@ class UpdateDebuggerVariableValueTest extends BaseTest {
 		waitBreakpointNotification(2);
 		awaitAllVariablesFilled(1, DEFAULT_VARIABLES_NUMBER + NUMBER_OF_HEADER + NUMBER_OF_EXCHANGE_PROPERTY + NUMBER_OF_EXCHANGE_PROPERTY_PARENT);
 		
-		String messagesAsXml = server.getConnectionManager().getBacklogDebugger().dumpTracedMessagesAsXml(SECOND_LOG_ID);
+		// Keep using deprecated method to have it still working with 4.1-
+		String messagesAsXml = server.getConnectionManager().getBacklogDebugger().dumpTracedMessagesAsXml(SECOND_LOG_ID, true);
 		EventMessage eventMessage = new UnmarshallerEventMessage().getUnmarshalledEventMessage(messagesAsXml);
 		return eventMessage;
 	}


### PR DESCRIPTION
it would throw this kind of exception otherwise: `Caused by: java.lang.NoSuchMethodException:
org.apache.camel.management.mbean.ManagedBacklogDebugger.dumpTracedMessagesAsXml(java.lang.String)`