### PR TITLE
Fix upload of artifact log at end of job build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
       run: mvn -B package
     - uses: actions/upload-artifact@v4
       with:
-        name: log-camel-dap.log
+        name: log-camel-dap-${{ matrix.java }}.log
         path: /tmp/log-camel-dap.log
         if-no-files-found: error
       if: ${{ always() && runner.os == 'Linux' }}


### PR DESCRIPTION
avoid 2 jobs from the matrix uploading with same name