### PR TITLE
FUSETOOLS2-2407- Support Pause for all routes and route by route

### DIFF
--- a/.settings/Test camel-dap-server.launch
+++ b/.settings/Test camel-dap-server.launch
@@ -1,19 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
     <stringAttribute key="bad_container_name" value="/camel-dap-server/.setti"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
         <listEntry value="/camel-dap-server"/>
     </listAttribute>
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
         <listEntry value="4"/>
     </listAttribute>
+    <mapAttribute key="org.eclipse.debug.core.preferred_launchers"/>
     <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=camel-dap-server"/>
     <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
     <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit5"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
     <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21/"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="camel-dap-server"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The Camel Debug Server Adapter must use Java Runtime Environment 11+ with `com.s
 - Inspect some variables when breakpoint is hit
 - Stop on hit breakpoint
 - Resume a single route instance and resume all
+- Pause and resume route definitions (technically suspend/resume or stop/start Camel routes depending if they are suspendable or not)
 - Stepping when the route definition is in the same file
 - Update values of:
   - Common variables which are grouped in `Debugger` scope

--- a/src/main/java/com/github/cameltooling/dap/internal/model/CamelExchangeThread.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/CamelExchangeThread.java
@@ -27,13 +27,13 @@ import org.eclipse.lsp4j.debug.Variable;
 import com.github.cameltooling.dap.internal.IdUtils;
 import com.github.cameltooling.dap.internal.types.EventMessage;
 
-public class CamelThread extends Thread {
+public class CamelExchangeThread extends Thread {
 
 	private final String breakpointId;
 	private final CamelStackFrame stackFrame;
 	private final EventMessage eventMessage;
 
-	public CamelThread(int threadId, String breakpointId, EventMessage eventMessage, CamelBreakpoint camelBreakpoint) {
+	public CamelExchangeThread(int threadId, String breakpointId, EventMessage eventMessage, CamelBreakpoint camelBreakpoint) {
 		setId(threadId);
 		setName(eventMessage.getExchangeId());
 		this.breakpointId = breakpointId;
@@ -57,7 +57,7 @@ public class CamelThread extends Thread {
 		if (!super.equals(obj)) {
 			return false;
 		}
-		CamelThread that = (CamelThread) obj;
+		CamelExchangeThread that = (CamelExchangeThread) obj;
 		return Objects.equals(this.breakpointId, that.breakpointId)
 				&& Objects.equals(this.eventMessage, that.eventMessage)
 				&& Objects.equals(this.stackFrame, that.stackFrame);

--- a/src/main/java/com/github/cameltooling/dap/internal/model/CamelRouteDefinitionThread.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/CamelRouteDefinitionThread.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal.model;
+
+import org.eclipse.lsp4j.debug.Thread;
+
+import com.github.cameltooling.dap.internal.IdUtils;
+
+public class CamelRouteDefinitionThread extends Thread {
+
+	public CamelRouteDefinitionThread(String camelId) {
+		setName(camelId);
+		setId(IdUtils.getPositiveIntFromHashCode(camelId.hashCode()));
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/dap/internal/model/CamelStackFrame.java
+++ b/src/main/java/com/github/cameltooling/dap/internal/model/CamelStackFrame.java
@@ -39,7 +39,9 @@ public class CamelStackFrame extends StackFrame {
 		setId(frameId);
 		setName(breakpointId);
 		setSource(source);
-		setLine(line);
+		if (line !=null) {
+			setLine(line);
+		}
 	}
 	
 	public Set<CamelScope> createScopes() {

--- a/src/test/java/com/github/cameltooling/dap/internal/BasicDebugFlowTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/BasicDebugFlowTest.java
@@ -93,7 +93,7 @@ abstract class BasicDebugFlowTest extends BaseTest {
 
 		assertThat(clientProxy.getAllStacksAndVars()).hasSize(1);
 		StackAndVarOnStopEvent stackAndData = clientProxy.getAllStacksAndVars().get(0);
-		await().untilAsserted(() -> assertThat(stackAndData.getThreads()).hasSize(1));
+		await().untilAsserted(() -> assertThat(stackAndData.getThreads()).hasSize(2));
 		await().untilAsserted(() -> assertThat(stackAndData.getStackFrames()).hasSize(1));
 		await().untilAsserted(() -> assertThat(stackAndData.getScopes()).hasSize(5));
 		await("handling of stop event response is finished")

--- a/src/test/java/com/github/cameltooling/dap/internal/CamelSuspendModeTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/CamelSuspendModeTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * A test ensuring that message processing can be suspended.
  */
-class SuspendTest extends BaseTest {
+class CamelSuspendModeTest extends BaseTest {
 
 	@Test
 	@SetSystemProperty(key = BacklogDebugger.SUSPEND_MODE_SYSTEM_PROP_NAME, value = "true")

--- a/src/test/java/com/github/cameltooling/dap/internal/ConditionalBreakpointTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/ConditionalBreakpointTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -31,7 +32,10 @@ import org.eclipse.lsp4j.debug.Source;
 import org.eclipse.lsp4j.debug.SourceBreakpoint;
 import org.eclipse.lsp4j.debug.StoppedEventArguments;
 import org.eclipse.lsp4j.debug.StoppedEventArgumentsReason;
+import org.eclipse.lsp4j.debug.Thread;
 import org.junit.jupiter.api.Test;
+
+import com.github.cameltooling.dap.internal.model.CamelExchangeThread;
 
 class ConditionalBreakpointTest extends BaseTest {
 
@@ -76,7 +80,8 @@ class ConditionalBreakpointTest extends BaseTest {
 
 		waitRouteIsDone(asyncSendBody2);
 
-		assertThat(server.threads().get().getThreads()).isEmpty();
+		Thread[] threads = server.threads().get().getThreads();
+		assertThat(Stream.of(threads)).doesNotHaveAnyElementsOfTypes(CamelExchangeThread.class);
 	}
 	
 	

--- a/src/test/java/com/github/cameltooling/dap/internal/DummyCamelDebugClient.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/DummyCamelDebugClient.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import org.eclipse.lsp4j.debug.ContinuedEventArguments;
 import org.eclipse.lsp4j.debug.OutputEventArguments;
 import org.eclipse.lsp4j.debug.OutputEventArgumentsCategory;
 import org.eclipse.lsp4j.debug.Scope;
@@ -46,6 +47,7 @@ public class DummyCamelDebugClient implements IDebugProtocolClient {
 	private final List<ThreadEventArguments> threadEventArgumentss = new ArrayList<>();
 	private final List<OutputEventArguments> telemetryEvents = new ArrayList<>();
 	private final List<OutputEventArguments> outputEventArguments = new ArrayList<>();
+	private final List<ContinuedEventArguments> continuedEventArgumentss = new ArrayList<ContinuedEventArguments>();
 	private final CamelDebugAdapterServer server;
 
 	public DummyCamelDebugClient(CamelDebugAdapterServer server) {
@@ -125,6 +127,11 @@ public class DummyCamelDebugClient implements IDebugProtocolClient {
 	public void thread(ThreadEventArguments args) {
 		threadEventArgumentss.add(args);
 	}
+	
+	@Override
+	public void continued(ContinuedEventArguments args) {
+		getContinuedEventArgumentss().add(args);
+	}
 
 	public List<StoppedEventArguments> getStoppedEventArguments() {
 		return stoppedEventArguments;
@@ -144,6 +151,10 @@ public class DummyCamelDebugClient implements IDebugProtocolClient {
 
 	public List<OutputEventArguments> getOutputEventArguments() {
 		return outputEventArguments;
+	}
+
+	public List<ContinuedEventArguments> getContinuedEventArgumentss() {
+		return continuedEventArgumentss;
 	}
 
 }

--- a/src/test/java/com/github/cameltooling/dap/internal/NextStepTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/NextStepTest.java
@@ -19,6 +19,7 @@ package com.github.cameltooling.dap.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -28,7 +29,10 @@ import org.eclipse.lsp4j.debug.NextArguments;
 import org.eclipse.lsp4j.debug.SetBreakpointsArguments;
 import org.eclipse.lsp4j.debug.StoppedEventArguments;
 import org.eclipse.lsp4j.debug.StoppedEventArgumentsReason;
+import org.eclipse.lsp4j.debug.Thread;
 import org.junit.jupiter.api.Test;
+
+import com.github.cameltooling.dap.internal.model.CamelExchangeThread;
 
 class NextStepTest extends BaseTest {
 	
@@ -83,7 +87,8 @@ class NextStepTest extends BaseTest {
 
 		waitRouteIsDone(asyncSendBody);
 
-		assertThat(server.threads().get().getThreads()).isEmpty();
+		Thread[] threads = server.threads().get().getThreads();
+		assertThat(Stream.of(threads)).doesNotHaveAnyElementsOfTypes(CamelExchangeThread.class);
 	}
 
 	@Test
@@ -122,6 +127,7 @@ class NextStepTest extends BaseTest {
 		assertThat(stoppedEventArgument.getReason()).isEqualTo(StoppedEventArgumentsReason.BREAKPOINT);
 		assertThat(asyncSendBody.isDone()).isFalse();
 		awaitAllVariablesFilled(0);
+		assertThat(server.threads().get().getThreads()).hasSize(2);
 
 		NextArguments nextArguments = new NextArguments();
 		nextArguments.setThreadId(1);
@@ -129,7 +135,8 @@ class NextStepTest extends BaseTest {
 
 		waitRouteIsDone(asyncSendBody);
 
-		assertThat(server.threads().get().getThreads()).isEmpty();
+		Thread[] threads = server.threads().get().getThreads();
+		assertThat(Stream.of(threads)).doesNotHaveAnyElementsOfTypes(CamelExchangeThread.class);
 	}
 	
 	@Test
@@ -183,6 +190,7 @@ class NextStepTest extends BaseTest {
 
 		waitRouteIsDone(asyncSendBody);
 
-		assertThat(server.threads().get().getThreads()).isEmpty();
+		Thread[] threads = server.threads().get().getThreads();
+		assertThat(Stream.of(threads)).doesNotHaveAnyElementsOfTypes(CamelExchangeThread.class);
 	}
 }

--- a/src/test/java/com/github/cameltooling/dap/internal/PauseRouteDefinitionTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/PauseRouteDefinitionTest.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.dap.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.assertj.core.api.Condition;
+import org.eclipse.lsp4j.debug.ContinueArguments;
+import org.eclipse.lsp4j.debug.PauseArguments;
+import org.eclipse.lsp4j.debug.Thread;
+import org.eclipse.lsp4j.debug.ThreadEventArguments;
+import org.eclipse.lsp4j.debug.ThreadEventArgumentsReason;
+import org.junit.jupiter.api.Test;
+
+class PauseRouteDefinitionTest extends BaseTest {
+
+	private void createThreeRoutes() throws Exception {
+		context = new DefaultCamelContext();
+		context.setSourceLocationEnabled(true);
+		context.addRoutes(new RouteBuilder() {
+
+			@Override
+			public void configure() throws Exception {
+				from("direct:testThreads1")
+					.log("Log from test 1");
+
+				from("direct:testThreads2")
+					.log("Log from test 2");
+				
+				from("direct:testThreads3")
+					.log("Log from test 3");
+			}
+		});
+		context.start();
+		assertThat(context.isStarted()).isTrue();
+		
+		initDebugger();
+		attach(server);
+		
+		Condition<ThreadEventArguments> startedThreads = new Condition<>() {
+			@Override
+			public boolean matches(ThreadEventArguments args) {
+				return ThreadEventArgumentsReason.STARTED.equals(args.getReason());
+			}
+		};
+		
+		await("Thread Started events sent")
+			.untilAsserted(() -> assertThat(clientProxy.getThreadEventArgumentss()).haveExactly(3, startedThreads));
+	}
+	
+	@Test
+	void testPauseAll() throws Exception {
+		createThreeRoutes();
+
+		server.pause(new PauseArguments());
+		
+		// TODO: how to check that it is really Paused?
+		await("Stopped event sent")
+			.untilAsserted(() -> assertThat(clientProxy.getStoppedEventArguments()).hasSize(3));
+		
+		ContinueArguments continueArgs = new ContinueArguments();
+		continueArgs.setSingleThread(Boolean.FALSE);
+		server.continue_(continueArgs);
+		
+		await("Continue event sent")
+		.untilAsserted(() -> assertThat(clientProxy.getContinuedEventArgumentss()).hasSize(3));
+	}
+
+	@Test
+	void testPauseASingleRoute() throws Exception {
+		createThreeRoutes();
+		
+		Thread[] threads = server.threads().get().getThreads();
+		assertThat(threads).hasSize(3);
+		
+		PauseArguments args = new PauseArguments();
+		args.setThreadId(threads[0].getId());
+
+		server.pause(args);
+		
+		// TODO: how to check that it is really Paused?
+		await("Stopped event sent")
+			.untilAsserted(() -> assertThat(clientProxy.getStoppedEventArguments()).hasSize(1));
+		assertThat(clientProxy.getStoppedEventArguments().get(0).getAllThreadsStopped()).isFalse();
+		assertThat(clientProxy.getStoppedEventArguments().get(0).getThreadId()).isEqualTo(threads[0].getId());
+		
+		ContinueArguments continueArguments = new ContinueArguments();
+		continueArguments.setSingleThread(Boolean.TRUE);
+		continueArguments.setThreadId(threads[0].getId());
+		server.continue_(continueArguments);
+		
+		await("Continue event sent")
+			.untilAsserted(() -> assertThat(clientProxy.getContinuedEventArgumentss()).hasSize(1));
+		assertThat(clientProxy.getContinuedEventArgumentss().get(0).getAllThreadsContinued()).isFalse();
+		assertThat(clientProxy.getContinuedEventArgumentss().get(0).getThreadId()).isEqualTo(threads[0].getId());
+	}
+
+}

--- a/src/test/java/com/github/cameltooling/dap/internal/RemoveBreakpointTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/RemoveBreakpointTest.java
@@ -76,7 +76,7 @@ class RemoveBreakpointTest extends BaseTest {
 		
 		assertThat(clientProxy.getAllStacksAndVars()).hasSize(1);
 		StackAndVarOnStopEvent stackAndData = clientProxy.getAllStacksAndVars().get(0);
-		assertThat(stackAndData.getThreads()).hasSize(1);
+		assertThat(stackAndData.getThreads()).hasSize(2);
 		assertThat(stackAndData.getStackFrames()).hasSize(1);
 		assertThat(stackAndData.getScopes()).hasSize(5);
 

--- a/src/test/java/com/github/cameltooling/dap/internal/StepInTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/StepInTest.java
@@ -19,6 +19,7 @@ package com.github.cameltooling.dap.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -28,7 +29,10 @@ import org.eclipse.lsp4j.debug.SetBreakpointsArguments;
 import org.eclipse.lsp4j.debug.StepInArguments;
 import org.eclipse.lsp4j.debug.StoppedEventArguments;
 import org.eclipse.lsp4j.debug.StoppedEventArgumentsReason;
+import org.eclipse.lsp4j.debug.Thread;
 import org.junit.jupiter.api.Test;
+
+import com.github.cameltooling.dap.internal.model.CamelExchangeThread;
 
 class StepInTest extends BaseTest {
 	
@@ -83,7 +87,8 @@ class StepInTest extends BaseTest {
 
 		waitRouteIsDone(asyncSendBody);
 
-		assertThat(server.threads().get().getThreads()).isEmpty();
+		Thread[] threads = server.threads().get().getThreads();
+		assertThat(Stream.of(threads)).doesNotHaveAnyElementsOfTypes(CamelExchangeThread.class);
 	}
 
 }

--- a/src/test/java/com/github/cameltooling/dap/internal/StepOutTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/StepOutTest.java
@@ -19,6 +19,7 @@ package com.github.cameltooling.dap.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
@@ -28,7 +29,10 @@ import org.eclipse.lsp4j.debug.SetBreakpointsArguments;
 import org.eclipse.lsp4j.debug.StepOutArguments;
 import org.eclipse.lsp4j.debug.StoppedEventArguments;
 import org.eclipse.lsp4j.debug.StoppedEventArgumentsReason;
+import org.eclipse.lsp4j.debug.Thread;
 import org.junit.jupiter.api.Test;
+
+import com.github.cameltooling.dap.internal.model.CamelExchangeThread;
 
 class StepOutTest extends BaseTest {
 	
@@ -83,7 +87,8 @@ class StepOutTest extends BaseTest {
 
 		waitRouteIsDone(asyncSendBody);
 
-		assertThat(server.threads().get().getThreads()).isEmpty();
+		Thread[] threads = server.threads().get().getThreads();
+		assertThat(Stream.of(threads)).doesNotHaveAnyElementsOfTypes(CamelExchangeThread.class);
 	}
 
 }


### PR DESCRIPTION
/!\ in VS Code, when there is a single thread (which means a single
route running for us), the thread is not displayed!!!
/!\ in VS Code, when there is a single thread (which means a single
route running for us), the thread is not displayed!!!

Next iterations:
- provide more information on the route displayed in the variables, when
on pause, it will avoid having empty views when pausing and there is a
single route https://issues.redhat.com/browse/FUSETOOLS2-2416
- provide route instances suspended when the route definition is
suspended - requires https://issues.apache.org/jira/browse/CAMEL-20908
![pauseResumeSeveralRoutes](https://github.com/camel-tooling/camel-debug-adapter/assets/1105127/e8a69674-7c77-4920-9540-66d5c2a92728)

![pauseResumeSingleRoute](https://github.com/camel-tooling/camel-debug-adapter/assets/1105127/bae6d298-4274-4a26-92cd-d99a0f9a074a)
