### PR TITLE
Fix deploy by using encrypted username

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,7 +33,7 @@ jobs:
     - name: Build, sign and deploy
       run: mvn -P sign -B deploy
       env:
-        MAVEN_USERNAME: apupier
+        MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME_TOKEN }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
         MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
     - name: Sonar analysis


### PR DESCRIPTION
current error:
```
 Error:  Failed to execute goal
org.sonatype.plugins:nexus-staging-maven-plugin:1.7.0:deploy
(injected-nexus-deploy) on project camel-dap-server: Failed to deploy
artifacts: Could not transfer artifact
com.github.camel-tooling:camel-dap-server:jar:javadoc:1.2.0-20240628.075713-4
from/to ossrh (https://oss.sonatype.org/content/repositories/snapshots):
authentication failed for
https://oss.sonatype.org/content/repositories/snapshots/com/github/camel-tooling/camel-dap-server/1.2.0-SNAPSHOT/camel-dap-server-1.2.0-20240628.075713-4-javadoc.jar,
status: 401 Content access is protected by token -> [Help 1]
```

secrets in configuration of github repository has been updated
![image](https://github.com/camel-tooling/camel-debug-adapter/assets/1105127/dd24c0da-4895-47f1-b397-b11a28ba5da6)
