### PR TITLE
FUSETOOLS2-1428 - Activate JMX over http

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
 		<!-- must be aligned with the one from Camel -->
 		<version.jaxb>4.0.0</version.jaxb>
 		<version.junit.pioneer>2.2.0</version.junit.pioneer>
+		<version-jolokia>2.0.3</version-jolokia>
 	</properties>
 	<build>
 		<plugins>
@@ -187,7 +188,18 @@
 			<version>${version.jaxb}</version>
 			<scope>runtime</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>org.jolokia</groupId>
+			<artifactId>jolokia-client-jmx-adapter</artifactId>
+			<version>${version-jolokia}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jolokia</groupId>
+			<artifactId>jolokia-client-java</artifactId>
+			<version>${version-jolokia}</version>
+			<scope>test</scope>
+		</dependency>
+		
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>

--- a/src/test/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServerTest.java
+++ b/src/test/java/com/github/cameltooling/dap/internal/CamelDebugAdapterServerTest.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,6 +58,18 @@ class CamelDebugAdapterServerTest extends BaseTest {
 		context.setSourceLocationEnabled(true);
 		startBasicRoute(context);
 		attachWithJMXURL(server, BacklogDebuggerConnectionManager.DEFAULT_JMX_URI);
+		checkConnectionEstablished();
+	}
+	
+	@Test
+	@Disabled("It is not possible to attach a jvm agent to itself. Consequently, not found a way to enable Jolokia in a Unit Test")
+	void testAttachToCamelWithJolokia() throws Exception {
+		context = new DefaultCamelContext();
+
+		// TODO : attach the jvm agent or launch the route in a separated process but how to check/interact with it then?
+		startBasicRoute(context);
+		
+		attachWithJMXURL(server, "service:jmx:jolokia://localhost:8778/jolokia/");
 		checkConnectionEstablished();
 	}
 	


### PR DESCRIPTION
by simply adding Jolokia 2 as a dependency

Writing a test is complicated, might be easier to provide an end to end test at VS code level. reported https://issues.redhat.com/browse/FUSETOOLS2-2424